### PR TITLE
Canviada búsqueda de línies bt

### DIFF
--- a/libcnmc/res_4603/LBT.py
+++ b/libcnmc/res_4603/LBT.py
@@ -25,7 +25,12 @@ class LBT(MultiprocessBased):
         self.report_name = 'CNMC INVENTARI BT'
 
     def get_sequence(self):
-        search_params = [('baixa', '=', False), ('cable.tipus.codi', '!=', 'E')]
+
+        search_params = [('cable.tipus.codi', '!=', 'E'),
+                         ('data_alta', '<', '01-01-%s' % (self.year + 1)), '|',
+                         ('data_baixa', '>', '31-12-%s' % self.year),
+                         ('data_baixa', '=', False),
+                         ]
         return self.connection.GiscedataBtElement.search(search_params)
 
     def consumer(self):


### PR DESCRIPTION
S'ha inclós la data de baixa i de alta a la búsqueda de les línies de baixa tensió.
Data de alta ha de ser menor que la del 1 del 1 de l'any següent i la data de baixa ha de ser major o inexistent a l'últim dia de l'any.
Eliminat buscar per el camp 'baixa'.
