### PR TITLE
Fix get ccaa

### DIFF
--- a/libcnmc/res_4603/FIA.py
+++ b/libcnmc/res_4603/FIA.py
@@ -144,7 +144,7 @@ class FIA(MultiprocessBased):
                                                       ['id_municipi'])
                     if id_municipi:
                         ccaa = O.ResComunitat_autonoma.get_ccaa_from_municipi(
-                            [], id_municipi['id_municipi'][0])[0]
+                            id_municipi['id_municipi'][0])[0]
 
                 elif cllinst[0] == 'giscedata.at.suport':
                     id_linia = O.GiscedataAtSuport.read(int(cllinst[1]),
@@ -153,7 +153,7 @@ class FIA(MultiprocessBased):
                         int(id_linia['linia'][0]), ['municipi'])
                     if id_municipi:
                         ccaa = O.ResComunitat_autonoma.get_ccaa_from_municipi(
-                            [], id_municipi['municipi'][0])[0]
+                            id_municipi['municipi'][0])[0]
 
                 output = [
                     '%s' % cll['name'],

--- a/libcnmc/res_4603/LAT.py
+++ b/libcnmc/res_4603/LAT.py
@@ -93,7 +93,7 @@ class LAT(MultiprocessBased):
                     comunitat = ''
                     if linia['municipi']:
                         id_comunitat = O.ResComunitat_autonoma.get_ccaa_from_municipi(
-                            [], linia['municipi'][0])
+                            linia['municipi'][0])
                         comunidad = O.ResComunitat_autonoma.read(id_comunitat,
                                                                  ['codi'])
                         if comunidad:

--- a/libcnmc/res_4603/LBT.py
+++ b/libcnmc/res_4603/LBT.py
@@ -73,7 +73,7 @@ class LBT(MultiprocessBased):
                 comunitat = ''
                 if linia['municipi']:
                     id_comunitat = O.ResComunitat_autonoma.get_ccaa_from_municipi(
-                        [], linia['municipi'][0])
+                        linia['municipi'][0])
                     id_comunitat = id_comunitat[0]
                     comunidad = O.ResComunitat_autonoma.read(id_comunitat,
                                                              ['codi'])

--- a/libcnmc/res_4603/MAQ.py
+++ b/libcnmc/res_4603/MAQ.py
@@ -66,7 +66,7 @@ class MAQ(MultiprocessBased):
                                               ['id_municipi',
                                                'perc_financament'])
                     id_comunitat = O.ResComunitat_autonoma.\
-                        get_ccaa_from_municipi([], cts['id_municipi'][0])
+                        get_ccaa_from_municipi(cts['id_municipi'][0])
                     comunidad = O.ResComunitat_autonoma.read(id_comunitat,
                                                              ['codi'])
                     if comunidad:


### PR DESCRIPTION
Canviades totes les funciones de get_ccaa_from_municipi, per treure el camp buit dels ids que passàvem.
També s'ha fet el canvi al codi de l'ERP, a el commit de la [NEW_1048](https://github.com/gisce/erp/pull/1611) [#100](https://github.com/gisce/erp/commit/ab5cb971d0df75368c7314a745a9ce88fd005c4a).
