### PR TITLE
IMP Capacidad MAQ with 3 decimals

### DIFF
--- a/libcnmc/res_4771/MAQ.py
+++ b/libcnmc/res_4771/MAQ.py
@@ -145,7 +145,7 @@ class MAQ(MultiprocessBased):
                     format_f(tensio_secundari),
                     format_f(financiacio),
                     data_pm,
-                    format_f(capacitat),
+                    format_f(capacitat, 3),
                 ]
 
                 self.output_q.put(output)


### PR DESCRIPTION
MAQ Capacidad with 3 decimals to avoid precission looses converting kVA to MVA 