### PR TITLE
get_node fix

### DIFF
--- a/libcnmc/cir_4_2015/F11.py
+++ b/libcnmc/cir_4_2015/F11.py
@@ -38,7 +38,7 @@ class F11(MultiprocessBased):
         vertex = None
         if bloc:
             bloc = O.GiscegisBlocsCtat.read(bloc[0], ['node', 'vertex'])
-            node = bloc['node'][0]
+            node = bloc['node'][1]
             if bloc['vertex']:
                 v = O.GiscegisVertex.read(bloc['vertex'][0], ['x', 'y'])
                 vertex = (round(v['x'], 3), round(v['y'], 3))

--- a/libcnmc/cir_4_2015/F12.py
+++ b/libcnmc/cir_4_2015/F12.py
@@ -40,7 +40,7 @@ class F12(MultiprocessBased):
         if bloc:
             bloc_vals = o.GiscegisBlocsTransformadors.read(
                 bloc[0], ['node'])
-            node = bloc_vals['node'][0]
+            node = bloc_vals['node'][1]
         return node
 
     def consumer(self):

--- a/libcnmc/cir_4_2015/F13bis.py
+++ b/libcnmc/cir_4_2015/F13bis.py
@@ -34,11 +34,11 @@ class F13bis(MultiprocessBased):
         sub = o.GiscedataCtsSubestacions.read(sub_id, ['ct_id', 'cini'])
         ct_id = sub['ct_id'][0]
         cini = sub['cini']
-        bloc = o.GiscegisBlocsCtat.search([('ct', '=', ct_id)])
+        bloc_ids = o.GiscegisBlocsCtat.search([('ct', '=', ct_id)])
         node = ''
-        if bloc:
-            bloc = o.GiscegisBlocsCtat.read(bloc[0], ['node'])
-            node = bloc['node'][0]
+        if bloc_ids:
+            bloc = o.GiscegisBlocsCtat.read(bloc_ids[0], ['node'])
+            node = bloc['node'][1]
         else:
             print "ct id: {}".format(ct_id)
         return {'node': node, 'cini': cini}

--- a/libcnmc/cir_4_2015/F15.py
+++ b/libcnmc/cir_4_2015/F15.py
@@ -31,7 +31,7 @@ class F15(MultiprocessBased):
                     bloc[0], ['node', 'vertex'])
                 v = o.GiscegisVertex.read(bloc['vertex'][0], ['x', 'y'])
                 if bloc.get('node', False):
-                    node = bloc['node'][0]
+                    node = bloc['node'][1]
                 else:
                     node = v['id']
                 if bloc.get('vertex', False):


### PR DESCRIPTION
Function now retrieves block name instead of the ID.