### PR TITLE
libCNMC - Fix F1Bis readings

### DIFF
--- a/libcnmc/cir_4_2015/F1bis.py
+++ b/libcnmc/cir_4_2015/F1bis.py
@@ -117,7 +117,7 @@ class F1bis(MultiprocessBased):
                     o_comptador_cini = ''
                     o_comptador_data = ''
                 o_num_lectures = format_f(
-                    cups['cnmc_numero_lectures'], decimals=3) or ''
+                    cups['cnmc_numero_lectures'], decimals=3) or '0'
                 o_titular = self.get_cambio_titularidad(cups['id'])
                 o_baixa = self.get_baixa_cups(cups['id'])
                 o_year = self.year


### PR DESCRIPTION
When there're not readings now 0 is printed instead of empty char ' '