### PR TITLE
FIX 4666 trafo search params

### DIFF
--- a/libcnmc/cli_4666.py
+++ b/libcnmc/cli_4666.py
@@ -384,7 +384,7 @@ def res_4666_maq(**kwargs):
     :rtype: None 
     """
 
-    from libcnmc.res_4131 import MAQ
+    from libcnmc.res_4666 import MAQ
     kwargs["compare_field"] = "4131_entregada_{}".format(kwargs["year"])
     res_lat(MAQ, **kwargs)
 

--- a/libcnmc/res_4666/MAQ.py
+++ b/libcnmc/res_4666/MAQ.py
@@ -69,7 +69,7 @@ class MAQ(MultiprocessBased):
         search_params_transformadors = search_params + [
             ('id_estat.cnmc_inventari', '=', True),
             ('localitzacio.code', '=', '1'),
-            ('id_estat.codi', '!=', '1')]
+            ('id_estat.codi', '=', '1')]
 
         #search_params_reductor += search_params
         ids_reductor = self.connection.GiscedataTransformadorTrafo.search(


### PR DESCRIPTION
This PR fixes the 4666 machines file. The error was de trafo search params, id_estat.codi must be 1 if the trafo is in "working" condition.