### PR TITLE
Update the filters to the new BOE-2017 criteria

### DIFF
--- a/libcnmc/cir_4_2015/F12bis.py
+++ b/libcnmc/cir_4_2015/F12bis.py
@@ -90,6 +90,8 @@ class F12bis(MultiprocessBased):
                 if celles['data_pm']:
                     o_data = datetime.strptime(celles['data_pm'], "%Y-%m-%d")
                     o_data = int(o_data.year)
+                if o_maquina == '':
+                    o_maquina = 999999
                 o_any = self.year
 
                 self.output_q.put([

--- a/libcnmc/cir_4_2015/F12bis.py
+++ b/libcnmc/cir_4_2015/F12bis.py
@@ -13,8 +13,7 @@ class F12bis(MultiprocessBased):
 
     def get_sequence(self):
         search_params = [
-            ('inventari', '=', 'fiabilitat'),
-            ('cini', 'ilike', 'i28_2%')
+            ('cini', 'ilike', 'i28')
         ]
         data_pm = '%s-01-01' % (self.year + 1)
         data_baixa = '%s-12-31' % self.year

--- a/libcnmc/cir_4_2015/F12bis.py
+++ b/libcnmc/cir_4_2015/F12bis.py
@@ -13,8 +13,8 @@ class F12bis(MultiprocessBased):
 
     def get_sequence(self):
         search_params = [
-            # ('inventari', '=', 'l2+p'),
-            ('installacio', 'like', 'giscedata.cts')
+            ('inventari', '=', 'fiabilitat'),
+            ('cini', 'ilike', 'i28_2%')
         ]
         data_pm = '%s-01-01' % (self.year + 1)
         data_baixa = '%s-12-31' % self.year

--- a/libcnmc/cir_4_2015/F13C.py
+++ b/libcnmc/cir_4_2015/F13C.py
@@ -72,8 +72,11 @@ class F13c(MultiprocessBased):
                 o_pos = sub['name']
                 o_cini = sub['cini']
                 o_prop = int(sub['propietari'])
-                o_data = datetime.strptime(sub['data_pm'], "%Y-%m-%d")
-                o_data = int(o_data.year)
+                if not sub['data_pm']:
+                    o_data = ""
+                else:
+                    o_data = datetime.strptime(sub['data_pm'], "%Y-%m-%d")
+                    o_data = int(o_data.year)
                 o_any = self.year
 
                 self.output_q.put([

--- a/libcnmc/cir_4_2015/F13C.py
+++ b/libcnmc/cir_4_2015/F13C.py
@@ -17,7 +17,7 @@ class F13c(MultiprocessBased):
         self.base_object = 'CTS'
 
     def get_sequence(self):
-        search_params = [('interruptor', '=', '2')]
+        search_params = [('cini', 'ilike', 'i28%')]
         data_pm = '%s-01-01' % (self.year + 1)
         data_baixa = '%s-12-31' % self.year
         search_params += ['|', ('data_pm', '=', False),

--- a/libcnmc/cir_4_2015/F15.py
+++ b/libcnmc/cir_4_2015/F15.py
@@ -14,7 +14,9 @@ class F15(MultiprocessBased):
 
     def get_sequence(self):
         search_params = [
-            ('installacio', 'ilike', 'giscedata.at.suport,%')
+            ('installacio', 'ilike', 'giscedata.at.suport,%'),
+            ('inventari', '=', 'fiabilitat'),
+            ('cini', 'not ilike', 'i28_2%')
         ]
         return self.connection.GiscedataCellesCella.search(search_params)
 

--- a/libcnmc/cir_4_2015/F15.py
+++ b/libcnmc/cir_4_2015/F15.py
@@ -160,7 +160,10 @@ class F15(MultiprocessBased):
                     o_node, vertex, o_tram = self.get_node_vertex_tram(
                         o_fiabilitat)
                 else:
-                    o_tram = celles['tram_id']
+                    o_tram = "A{0}".format(o.GiscedataAtTram.read(
+                        celles['tram_id'][0], ['name']
+                    )['name'])
+
                     o_node, vertex = self.get_node_vertex(o_fiabilitat)
 
                 o_node = o_node.replace('*', '')

--- a/libcnmc/cir_4_2015/F15.py
+++ b/libcnmc/cir_4_2015/F15.py
@@ -124,7 +124,10 @@ class F15(MultiprocessBased):
                 )
                 dict_linia = self.obtenir_camps_linia(celles['installacio'])
                 o_fiabilitat = celles['name']
+
                 o_node, vertex, o_tram = self.get_node_vertex_tram(o_fiabilitat)
+                if celles["ccamp"]:
+                    o_tram = camp
                 o_node = o_node.replace('*', '')
                 o_cini = celles['cini']
                 z = ''

--- a/libcnmc/res_4666/CON.py
+++ b/libcnmc/res_4666/CON.py
@@ -16,7 +16,7 @@ from libcnmc.utils import format_f
 
 class CON(MultiprocessBased):
     """
-    Class that generates the Maquinas/Condensadores(5) file of the 4131
+    Class that generates the Maquinas/Condensadores(5) file of the 4666
     """
     def __init__(self, **kwargs):
         """

--- a/libcnmc/res_4666/CTS.py
+++ b/libcnmc/res_4666/CTS.py
@@ -132,7 +132,13 @@ class CTS(MultiprocessBased):
                     else:
                         estado = '1'
                 else:
-                    estado = '2'
+                    if ct['data_pm']:
+                        if ct['data_pm'][:4] != str(self.year):
+                            estado = '1'
+                        else:
+                            estado = '2'
+                    else:
+                        estado = '1'
                 if ct['tipus_instalacio_cnmc_id']:
                     id_ti = ct['tipus_instalacio_cnmc_id'][0]
                     ti = O.GiscedataTipusInstallacio.read(

--- a/libcnmc/res_4666/CTS.py
+++ b/libcnmc/res_4666/CTS.py
@@ -15,7 +15,7 @@ from libcnmc.models import F8Res4131
 
 class CTS(MultiprocessBased):
     """
-    Class that generates the CT file of the 4131
+    Class that generates the CT file of the 4666
     """
     def __init__(self, **kwargs):
         """

--- a/libcnmc/res_4666/DES.py
+++ b/libcnmc/res_4666/DES.py
@@ -15,7 +15,7 @@ from libcnmc.models import F6Res4131
 
 class DES(MultiprocessBased):
     """
-    Class that generates the Despachos(6) file of the 4131
+    Class that generates the Despachos(6) file of the 4666
     """
     def __init__(self, **kwargs):
         """

--- a/libcnmc/res_4666/DES.py
+++ b/libcnmc/res_4666/DES.py
@@ -77,7 +77,13 @@ class DES(MultiprocessBased):
                     else:
                         estado = '1'
                 else:
-                    estado = '2'
+                    if despatx['data_pm']:
+                        if despatx['data_pm'][:4] != str(self.year):
+                            estado = '1'
+                        else:
+                            estado = '2'
+                    else:
+                        estado = '1'
                 output = [
                     '{0}'.format(despatx['name']),
                     despatx['cini'] or '',

--- a/libcnmc/res_4666/FIA.py
+++ b/libcnmc/res_4666/FIA.py
@@ -14,7 +14,7 @@ from libcnmc.models import F7Res4131
 
 class FIA(MultiprocessBased):
     """
-    Class that generates the fiabilidad(7) file of the 4131
+    Class that generates the fiabilidad(7) file of the 4666
     """
     def __init__(self, **kwargs):
         """

--- a/libcnmc/res_4666/FIA.py
+++ b/libcnmc/res_4666/FIA.py
@@ -154,7 +154,13 @@ class FIA(MultiprocessBased):
                     else:
                         estado = '1'
                 else:
-                    estado = '2'
+                    if cll['data_pm']:
+                        if cll['data_pm'][:4] != str(self.year):
+                            estado = '1'
+                        else:
+                            estado = '2'
+                    else:
+                        estado = '1'
 
                 output = [
                     '{0}'.format(cll['name']),

--- a/libcnmc/res_4666/LAT.py
+++ b/libcnmc/res_4666/LAT.py
@@ -243,7 +243,13 @@ class LAT(MultiprocessBased):
                         else:
                             estado = 1
                     else:
-                        estado = 2
+                        if tram['data_pm']:
+                            if tram['data_pm'][:4] != str(self.year):
+                                estado = '1'
+                            else:
+                                estado = '2'
+                        else:
+                            estado = '1'
 
                     output = [
                         'A{0}'.format(tram['name']),

--- a/libcnmc/res_4666/LAT.py
+++ b/libcnmc/res_4666/LAT.py
@@ -16,7 +16,7 @@ from libcnmc.models import F1Res4131
 
 class LAT(MultiprocessBased):
     """
-    Class that generates the LAT(1) file of  4131
+    Class that generates the LAT(1) file of  4666
     """
     def __init__(self, **kwargs):
         """

--- a/libcnmc/res_4666/LBT.py
+++ b/libcnmc/res_4666/LBT.py
@@ -203,7 +203,13 @@ class LBT(MultiprocessBased):
                     else:
                         estado = 1
                 else:
-                    estado = 2
+                    if linia['data_pm']:
+                        if linia['data_pm'][:4] != str(self.year):
+                            estado = '1'
+                        else:
+                            estado = '2'
+                    else:
+                        estado = '1'
 
                 output = [
                     'B{}'.format(linia['name']),

--- a/libcnmc/res_4666/LBT.py
+++ b/libcnmc/res_4666/LBT.py
@@ -19,7 +19,7 @@ QUIET = False
 
 class LBT(MultiprocessBased):
     """
-    Class that generates the LBT(2) file of the 4131
+    Class that generates the LBT(2) file of the 4666
     """
     def __init__(self, **kwargs):
         """

--- a/libcnmc/res_4666/MAQ.py
+++ b/libcnmc/res_4666/MAQ.py
@@ -17,7 +17,7 @@ from libcnmc.models import F5Res4131
 
 class MAQ(MultiprocessBased):
     """
-    Class that generates the Maquinas/Transofrmadores(5) file of the 4131
+    Class that generates the Maquinas/Transofrmadores(5) file of the 4666
     """
     def __init__(self, **kwargs):
         """

--- a/libcnmc/res_4666/MAQ.py
+++ b/libcnmc/res_4666/MAQ.py
@@ -211,7 +211,13 @@ class MAQ(MultiprocessBased):
                     else:
                         estado = '1'
                 else:
-                    estado = '2'
+                    if trafo['data_pm']:
+                        if trafo['data_pm'][:4] != str(self.year):
+                            estado = '1'
+                        else:
+                            estado = '2'
+                    else:
+                        estado = '1'
 
                 output = [
                     '{0}'.format(trafo['name']),

--- a/libcnmc/res_4666/POS.py
+++ b/libcnmc/res_4666/POS.py
@@ -185,7 +185,13 @@ class POS(MultiprocessBased):
                     else:
                         estado = 1
                 else:
-                    estado = 2
+                    if pos['data_pm']:
+                        if pos['data_pm'][:4] != str(self.year):
+                            estado = '1'
+                        else:
+                            estado = '2'
+                    else:
+                        estado = '1'
                 output = [
                     o_sub,
                     pos['cini'] or '',
@@ -352,7 +358,14 @@ class POS_INT(MultiprocessBased):
                     else:
                         estado = 1
                 else:
-                    estado = 2
+                    if cel['data_pm']:
+                        if cel['data_pm'][:4] != str(self.year):
+                            estado = '1'
+                        else:
+                            estado = '2'
+                    else:
+                        estado = '1'
+
                 output = [
                     identificador,
                     cel["cini"] or "",

--- a/libcnmc/res_4666/POS.py
+++ b/libcnmc/res_4666/POS.py
@@ -38,7 +38,7 @@ class POS(MultiprocessBased):
         Method that generates a list of ids to pass to the consummer
         :return: List of ids
         """
-        search_params = [('interruptor', '=', '2')]
+        search_params = [('cini', 'ilike', 'i28_2%')]
         data_pm = '{0}-01-01'.format(self.year + 1)
         data_baixa = '{0}-01-01'.format(self.year)
         search_params += [('propietari', '=', True),
@@ -230,7 +230,8 @@ class POS_INT(MultiprocessBased):
         Method that generates a list of ids to pass to the consummer
         :return: List of ids
         """
-        search_params = [('cini', 'like', 'I28')]
+        search_params = [('inventari', '=', 'fiabilitat'),
+                         ('cini', 'ilike', 'i28_2%')]
         data_pm = '{0}-01-01'.format(self.year + 1)
         search_params += ['|', ('data_pm', '=', False),
                           ('data_pm', '<', data_pm)]
@@ -272,7 +273,7 @@ class POS_INT(MultiprocessBased):
         o = self.connection
         res = ''
 
-        denom = o.GiscedataCts.read(ct_id, ['descripcio'])['descripcio']
+        denom = o.GiscedataCts.read(ct_id, ['name'])['name']
         if denom:
             res = denom
         return res

--- a/libcnmc/res_4666/POS.py
+++ b/libcnmc/res_4666/POS.py
@@ -18,7 +18,7 @@ QUIET = False
 
 class POS(MultiprocessBased):
     """
-    Class that generates the POS/Interruptores(4) of 4131 report
+    Class that generates the POS/Interruptores(4) of 4666 report
     """
     def __init__(self, **kwargs):
         """
@@ -210,7 +210,7 @@ class POS(MultiprocessBased):
 
 class POS_INT(MultiprocessBased):
     """
-    Class that generates the POS/Cel·les(4) of 4131 report
+    Class that generates the POS/Cel·les(4) of 4666 report
     """
     def __init__(self, **kwargs):
         """

--- a/libcnmc/res_4666/SUB.py
+++ b/libcnmc/res_4666/SUB.py
@@ -143,7 +143,13 @@ class SUB(MultiprocessBased):
                     else:
                         estado = 1
                 else:
-                    estado = 2
+                    if sub['data_pm']:
+                        if sub['data_pm'][:4] != str(self.year):
+                            estado = '1'
+                        else:
+                            estado = '2'
+                    else:
+                        estado = '1'
 
                 output = [
                     '{0}'.format(sub['name']),

--- a/libcnmc/res_4666/SUB.py
+++ b/libcnmc/res_4666/SUB.py
@@ -18,7 +18,7 @@ QUIET = False
 
 class SUB(MultiprocessBased):
     """
-    Class that generates the SUB(3) report of the 4131
+    Class that generates the SUB(3) report of the 4666
     """
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
Implementing the changes provided in the BOE to classify the items correctly in each inventory made by the module.
Filter Criteria:
- [x] 4/2015 F12BIS.
- [x] 4/2015 F15.
- [x] 4/2015 F13C.
- [x] 4666 F4.

Also updated the estat classify criteria for all the elements on the 4666.