### PR TITLE
Añadir posibildad de añadir valores por defecto en el F1 4/2015

### DIFF
--- a/libcnmc/cir_4_2015/F1.py
+++ b/libcnmc/cir_4_2015/F1.py
@@ -290,7 +290,7 @@ class F1(MultiprocessBased):
                         if id_config:
                             config = O.ResConfig.read(id_config[0], [])
                             default_values = literal_eval(config['value'])
-                            if defalut_values.get('o_cod_tfa'):
+                            if default_values.get('o_cod_tfa'):
                                 o_cod_tfa = default_values.get('o_cod_tfa')
                             if default_values.get('o_cnae'):
                                 o_cnae = default_values.get('o_cnae')

--- a/libcnmc/cir_4_2015/F1.py
+++ b/libcnmc/cir_4_2015/F1.py
@@ -280,6 +280,20 @@ class F1(MultiprocessBased):
                             )[0]['tensio']
                             o_tensio = format_f(
                                 float(tensio_gis) / 1000.0, decimals=3)
+                        from ast import literal_eval
+                        search_params = [
+                            ('name', '=', 'libcnmc_4_2015_default_f1')
+                        ]
+                        id_config = O.ResConfig.search(
+                            search_params
+                        )
+                        if id_config:
+                            config = O.ResConfig.read(id_config[0], [])
+                            default_values = literal_eval(config['value'])
+                            if defalut_values.get('o_cod_tfa'):
+                                o_cod_tfa = default_values.get('o_cod_tfa')
+                            if default_values.get('o_cnae'):
+                                o_cnae = default_values.get('o_cnae')
 
                 o_any_incorporacio = self.year
                 res_srid = ['', '']


### PR DESCRIPTION
Se añade una consulta a la variable res.config con el nombre `libcnmc_4_2015_default_f1` y el valor `{'o_cnae': '9820', 'o_cod_tfa': '416'}` para actualizar el valor del CNAE y la tarifa por defecto. 

Si no se define valor se dejará por defecto.