### PR TITLE
Fix bad field name on 4666_DES

### DIFF
--- a/libcnmc/res_4666/DES.py
+++ b/libcnmc/res_4666/DES.py
@@ -77,8 +77,8 @@ class DES(MultiprocessBased):
                     else:
                         estado = '1'
                 else:
-                    if despatx['data_pm']:
-                        if despatx['data_pm'][:4] != str(self.year):
+                    if despatx['data_apm']:
+                        if despatx['data_apm'][:4] != str(self.year):
                             estado = '1'
                         else:
                             estado = '2'


### PR DESCRIPTION
## Job Done
*  Fixed the name used to acces to a value of an element that was bad typed. 
*  Changed from **data_pm** to **data_apm**.