### PR TITLE
If has not data APM is not shown

### DIFF
--- a/libcnmc/res_4666/LBT.py
+++ b/libcnmc/res_4666/LBT.py
@@ -46,7 +46,6 @@ class LBT(MultiprocessBased):
         if not self.embarrats:
             search_params += [('cable.tipus.codi', '!=', 'E')]
         search_params += [('propietari', '=', True),
-                          '|', ('data_pm', '=', False),
                                ('data_pm', '<', data_pm),
                           '|', ('data_baixa', '>', data_baixa),
                                ('data_baixa', '=', False),


### PR DESCRIPTION
# Description
- If a BT element has no data_pm it will not apear on the file