### PR TITLE
Fix the way that FusAT are excluded.

### DIFF
--- a/libcnmc/cir_4_2015/F12bis.py
+++ b/libcnmc/cir_4_2015/F12bis.py
@@ -19,14 +19,15 @@ class F12bis(MultiprocessBased):
 
         :return: None
         """
-        id_fus_at = self.connection.GiscedataCellesTipusElement.search(
-            [("name", "like", "Fusible Alta Tensió")],
+        ids_fus_at = self.connection.GiscedataCellesCella.search(
+            ['|', ("cini", "like", "I26204%"), '|', ("cini", "like", "I26304%"),
+             ("cini", "like", "I26404%")],
             0, 0, False, {'active_test': False}
-        )[0]
+        )
 
         search_params = [
             ("installacio", "like", "giscedata.cts"),
-            ("tipus_element", "!=", id_fus_at)
+            ("id", "not in", ids_fus_at)
         ]
 
         if self.fiabilitat and self.doslmesp:


### PR DESCRIPTION
# Descripcion
- Fix the search params to exclude the FusibleAT to work correctly to everybody.

# Ficheros modificados
- Cir.4/2015: F12Bis