### PR TITLE
Include all tipus inventari on F15.

### DIFF
--- a/libcnmc/cir_4_2015/F15.py
+++ b/libcnmc/cir_4_2015/F15.py
@@ -124,7 +124,6 @@ class F15Cel(MultiprocessBased):
         :rtype: list(int)
         """
         search_params = [
-            ("inventari", "=", "fiabilitat"),
             ("installacio", "like", "giscedata.at.suport"),
             ("tipus_element.codi_cnmc", "!=", "T")
         ]


### PR DESCRIPTION
# Descripcion
- Before just the tipus inventari "fiabilitat" were listed. 
- Now all the tipus inventari "fiabilitat" and "l2+p" are listed on the file.

# Ficheros modificados
- Cir. 4/2015 : F15.
