### PR TITLE
Obtener la tension de las Posicions que son Celdas correctamente

### DIFF
--- a/libcnmc/res_4666/POS.py
+++ b/libcnmc/res_4666/POS.py
@@ -385,9 +385,10 @@ class POS_INT(MultiprocessBased):
                     codigo_ccuu = O.GiscedataTipusInstallacio.read(
                         id_ti, ["name"])["name"]
 
-                tensio = 0.000
-                if cel["tensio"]:
-                    tensio = float(cel["tensio"][1])/1000.0
+                ten = O.GiscedataTensionsTensio.read(
+                    cel['tensio'][0], ['tensio']
+                )
+                tensio = (ten['tensio'] / 1000.0) or 0.0
 
 
                 data_pm = ""


### PR DESCRIPTION
# Descripcion
- En la antigua implementacion, para calcular el campo "NIVEL_TENSION" de una Celda, se utilizava el campo `name` de la tension normalizada referenciada en el elemento. El caso es que ese valor es un campo de texto y se podia dar el caso de que el valor tuviera del formato "20.000". Al castear a float un string con este formato el valor passava a ser "20" en vez de "20000" a raiz de que en python el punto es el caracter que marca los decimales de un float. Ahora se utiliza el campo 'tensio' de la tension normalizada referenciada en las celda para poder calcular correctamente el campo "NIVEL_TENSION" del fichero.

# Ficheros modificados
- F4 de la 4666 (Posiciones)