### PR TITLE
Remove unnecessary and unused code lines from 4666-F2

### DIFF
--- a/libcnmc/res_4666/LBT.py
+++ b/libcnmc/res_4666/LBT.py
@@ -84,10 +84,7 @@ class LBT(MultiprocessBased):
             'data_alta', 'propietari', 'tipus_instalacio_cnmc_id', 'baixa',
             'data_baixa', self.compare_field
         ]
-        data_baixa_limit = '{0}-01-01'.format(self.year)
         data_pm_limit = '{0}-01-01'.format(self.year + 1)
-        error_msg = "**** ERROR: l'element {0} (id:{1}) no està en giscegis_edges.\n"
-        error_msg_multi = "**** ERROR: l'element {0} (id:{1}) està més d'una vegada a giscegis_edges. {2}\n"
         while True:
             try:
                 count += 1

--- a/libcnmc/res_4666/LBT.py
+++ b/libcnmc/res_4666/LBT.py
@@ -96,26 +96,6 @@ class LBT(MultiprocessBased):
 
                 linia = O.GiscedataBtElement.read(item, fields_to_read)
 
-                res = O.GiscegisEdge.search([('id_linktemplate', '=',
-                                              linia['name']),
-                                             ('layer', 'ilike', '%BT%')])
-                if not res:
-                    if not QUIET:
-                        sys.stderr.write(
-                            error_msg.format(linia['name'], linia['id']))
-                        sys.stderr.flush()
-                    edge = {'start_node': (0, '{0}_0'.format(linia['name'])),
-                            'end_node': (0, '{0}_1'.format(linia['name']))}
-                elif len(res) > 1:
-                    if not QUIET:
-                        sys.stderr.write(
-                            error_msg_multi.format(linia['name'], linia['id'], res))
-                        sys.stderr.flush()
-                    edge = {'start_node': (0, '{0}_0'.format(linia['name'])),
-                            'end_node': (0, '{0}_1'.format(linia['name']))}
-                else:
-                    edge = O.GiscegisEdge.read(res[0], ['start_node',
-                                                        'end_node'])
                 comunitat = ''
                 if linia['municipi']:
                     ccaa_obj = O.ResComunitat_autonoma
@@ -168,10 +148,6 @@ class LBT(MultiprocessBased):
 
                 if not capacitat:
                     capacitat = 1.0
-
-                # Descripció
-                origen = tallar_text(edge['start_node'][1], 50)
-                final = tallar_text(edge['end_node'][1], 50)
 
                 longitud = round(linia['longitud_cad'] * coeficient / 1000.0,
                                  3) or 0.001


### PR DESCRIPTION
# Descripcion
- Remove unnecessary and unused code lines from 4666-F2.
- The edges are not used anymore to get the 'origen' and 'desti' of the Tram BT.

# Ficheros modificados
- 4666-F2