### PR TITLE
Improve search parameters on 4666: F1, F2, F3, F4, F8 and MOD

### DIFF
--- a/libcnmc/res_4666/CTS.py
+++ b/libcnmc/res_4666/CTS.py
@@ -47,7 +47,10 @@ class CTS(MultiprocessBased):
                                ('data_pm', '<', data_pm),
                           '|',
                           '&', ('data_baixa', '>', data_baixa),
-                               ('ct_baixa', '=', True)
+                               ('ct_baixa', '=', True),
+                          '|',
+                               ('data_baixa', '=', False),
+                               ('ct_baixa', '=', False)
                           ]
         # Revisem que si està de baixa ha de tenir la data informada.
         search_params += ['|',

--- a/libcnmc/res_4666/CTS.py
+++ b/libcnmc/res_4666/CTS.py
@@ -47,7 +47,7 @@ class CTS(MultiprocessBased):
                                ('data_pm', '<', data_pm),
                           '|',
                           '&', ('data_baixa', '>', data_baixa),
-                               ('baixa', '=', True),
+                               ('ct_baixa', '=', True),
                                ('data_baixa', '=', False)
                           ]
         # Revisem que si està de baixa ha de tenir la data informada.

--- a/libcnmc/res_4666/CTS.py
+++ b/libcnmc/res_4666/CTS.py
@@ -45,7 +45,9 @@ class CTS(MultiprocessBased):
         search_params += [('propietari', '=', True),
                           '|', ('data_pm', '=', False),
                                ('data_pm', '<', data_pm),
-                          '|', ('data_baixa', '>', data_baixa),
+                          '|',
+                          '&', ('data_baixa', '>', data_baixa),
+                               ('baixa', '=', True),
                                ('data_baixa', '=', False)
                           ]
         # Revisem que si està de baixa ha de tenir la data informada.

--- a/libcnmc/res_4666/CTS.py
+++ b/libcnmc/res_4666/CTS.py
@@ -47,8 +47,7 @@ class CTS(MultiprocessBased):
                                ('data_pm', '<', data_pm),
                           '|',
                           '&', ('data_baixa', '>', data_baixa),
-                               ('ct_baixa', '=', True),
-                               ('data_baixa', '=', False)
+                               ('ct_baixa', '=', True)
                           ]
         # Revisem que si està de baixa ha de tenir la data informada.
         search_params += ['|',

--- a/libcnmc/res_4666/LAT.py
+++ b/libcnmc/res_4666/LAT.py
@@ -100,7 +100,12 @@ class LAT(MultiprocessBased):
         static_search_params = [
             ('propietari', '=', True),
             '|', ('data_pm', '=', False), ('data_pm', '<', data_pm_limit),
-            '|', ('data_baixa', '=', False), ('data_baixa', '>', data_baixa)
+            '|',
+            '&', ('data_baixa', '>', data_baixa),
+                 ('baixa', '=', True),
+            '|',
+                 ('data_baixa', '=', False),
+                 ('baixa', '=', False)
             ]
 
         # print 'static_search_params:{}'.format(static_search_params)

--- a/libcnmc/res_4666/LBT.py
+++ b/libcnmc/res_4666/LBT.py
@@ -49,9 +49,13 @@ class LBT(MultiprocessBased):
         if not self.embarrats:
             search_params += [('cable.tipus.codi', '!=', 'E')]
         search_params += [('propietari', '=', True),
-                               ('data_pm', '<', data_pm),
-                          '|', ('data_baixa', '>', data_baixa),
+                          ('data_pm', '<', data_pm),
+                          '|',
+                          '&', ('data_baixa', '>', data_baixa),
+                               ('baixa', '=', True),
+                          '|',
                                ('data_baixa', '=', False),
+                               ('baixa', '=', False)
                           ]
         # Revisem que si està de baixa ha de tenir la data informada.
         search_params += ['|',

--- a/libcnmc/res_4666/MAQ.py
+++ b/libcnmc/res_4666/MAQ.py
@@ -60,8 +60,12 @@ class MAQ(MultiprocessBased):
             ('propietari', '=', True),
             '|', ('data_pm', '=', False),
             ('data_pm', '<', data_pm),
-            '|', ('data_baixa', '>', data_baixa),
-            ('data_baixa', '=', False)
+            '|',
+            '&', ('data_baixa', '>', data_baixa),
+                 ('baixa', '=', True),
+            '|',
+                 ('data_baixa', '=', False),
+                 ('baixa', '=', False)
         ]
 
         # Transformadors reductors

--- a/libcnmc/res_4666/MOD.py
+++ b/libcnmc/res_4666/MOD.py
@@ -57,8 +57,12 @@ class ModCts(MultiprocessBased):
         search_params += [('propietari', '=', True),
                           '|', ('data_pm', '=', False),
                                ('data_pm', '<', data_pm),
-                          '|', ('data_baixa', '>', data_baixa),
-                               ('data_baixa', '=', False)
+                          '|',
+                          '&', ('data_baixa', '>', data_baixa),
+                               ('ct_baixa', '=', True),
+                          '|',
+                               ('data_baixa', '=', False),
+                               ('ct_baixa', '=', False)
                           ]
         # Revisem que si està de baixa ha de tenir la data informada.
         search_params += ['|',
@@ -340,8 +344,12 @@ class ModLbt(MultiprocessBased):
         search_params += [('propietari', '=', True),
                           '|', ('data_pm', '=', False),
                                ('data_pm', '<', data_pm),
-                          '|', ('data_baixa', '>', data_baixa),
+                          '|',
+                          '&', ('data_baixa', '>', data_baixa),
+                               ('baixa', '=', True),
+                          '|',
                                ('data_baixa', '=', False),
+                               ('baixa', '=', False)
                           ]
         # Revisem que si està de baixa ha de tenir la data informada.
         search_params += ['|',
@@ -429,8 +437,12 @@ class ModMaq(MultiprocessBased):
             ('propietari', '=', True),
             '|', ('data_pm', '=', False),
             ('data_pm', '<', data_pm),
-            '|', ('data_baixa', '>', data_baixa),
-            ('data_baixa', '=', False)
+            '|',
+            '&', ('data_baixa', '>', data_baixa),
+                 ('baixa', '=', True),
+            '|',
+                 ('data_baixa', '=', False),
+                 ('baixa', '=', False)
         ]
 
         # Transformadors reductors

--- a/libcnmc/res_4666/SUB.py
+++ b/libcnmc/res_4666/SUB.py
@@ -49,8 +49,12 @@ class SUB(MultiprocessBased):
         search_params += [('propietari', '=', True),
                           '|', ('data_pm', '=', False),
                           ('data_pm', '<', data_pm),
-                          '|', ('data_baixa', '>', data_baixa),
-                          ('data_baixa', '=', False)
+                          '|',
+                          '&', ('data_baixa', '>', data_baixa),
+                               ('baixa', '=', True),
+                          '|',
+                               ('data_baixa', '=', False),
+                               ('baixa', '=', False)
                           ]
         # Revisem que si està de baixa ha de tenir la data informada.
         search_params += ['|',

--- a/libcnmc/res_4666/SUB.py
+++ b/libcnmc/res_4666/SUB.py
@@ -51,10 +51,10 @@ class SUB(MultiprocessBased):
                           ('data_pm', '<', data_pm),
                           '|',
                           '&', ('data_baixa', '>', data_baixa),
-                               ('baixa', '=', True),
+                               ('ct_baixa', '=', True),
                           '|',
                                ('data_baixa', '=', False),
-                               ('baixa', '=', False)
+                               ('ct_baixa', '=', False)
                           ]
         # Revisem que si està de baixa ha de tenir la data informada.
         search_params += ['|',


### PR DESCRIPTION
# Descripcion
- Improve 4666 search parameters to include those elements wich have been 'baixa' but now are active again and have a 'data_baixa' set.

# Ficheros modificados
- 4666: 
  - F1
  - F2
  - F3
  - F4
  - F8
  - MOD