### PR TITLE
F1bis Solo en estado tall activa and baixa

### DIFF
--- a/libcnmc/cir_4_2015/F1bis.py
+++ b/libcnmc/cir_4_2015/F1bis.py
@@ -192,6 +192,7 @@ class F1bis(MultiprocessBased):
             ('cups', '=', cups_id),
             ('data_baixa', '>=', data_inici),
             ('data_baixa', '<', data_fi)
+            ('state', 'in', ['tall','activa','baixa'])
         ]
         polisses_baixa_ids = polissa_obj.search(
             search_params, 0, False, False, {'active_test': False})


### PR DESCRIPTION
# Descripcion
- En el F1 bis de la 4/2015 solo apareceran las polizas en estado tall, activa y baixa

# Ficheros modificados
- F1bis 4/2015