### PR TITLE
Fix the way that the CUPS are filtered on F1, F1bis, F11 and F20.

### DIFF
--- a/libcnmc/cir_4_2015/F1.py
+++ b/libcnmc/cir_4_2015/F1.py
@@ -154,6 +154,7 @@ class F1(MultiprocessBased):
         """
         data_ini = '%s-01-01' % (self.year + 1)
         search_params = [('active', '=', True),
+                         ('et', '=', 'CT-007'),
                          '|',
                          ('create_date', '<', data_ini),
                          ('create_date', '=', False)]

--- a/libcnmc/cir_4_2015/F1.py
+++ b/libcnmc/cir_4_2015/F1.py
@@ -154,7 +154,6 @@ class F1(MultiprocessBased):
         """
         data_ini = '%s-01-01' % (self.year + 1)
         search_params = [('active', '=', True),
-                         ('et', '=', ct_name),
                          '|',
                          ('create_date', '<', data_ini),
                          ('create_date', '=', False)]
@@ -272,7 +271,7 @@ class F1(MultiprocessBased):
                     'name', 'id_escomesa', 'id_municipi', 'cne_anual_activa',
                     'cne_anual_reactiva', 'cnmc_potencia_facturada', 'et',
                     'polisses', 'potencia_conveni', 'potencia_adscrita',
-                    "node_id"
+                    "node_id", 'et'
                 ]
                 cups = O.GiscedataCupsPs.read(item, fields_to_read)
                 if not cups or not cups.get('name'):
@@ -282,6 +281,7 @@ class F1(MultiprocessBased):
                     o_name = cups['name'][:20]
                 else:
                     o_name = cups['name'][:22]
+                o_et = cups['et']
                 o_codi_ine_mun = ''
                 o_codi_ine_prov = ''
                 o_zona = ''
@@ -485,7 +485,8 @@ class F1(MultiprocessBased):
                     format_f(o_pot_ads, decimals=3),        # Potencia adscrita a la instalacion
                     format_f(o_anual_activa, decimals=3),   # Energia activa anual consumida
                     format_f(o_anual_reactiva, decimals=3), # Energia reactiva anual consumida
-                    o_any_incorporacio  # Año informacion
+                    o_any_incorporacio,  # Año informacion
+                    o_et
                 ])
             except Exception:
                 traceback.print_exc()

--- a/libcnmc/cir_4_2015/F1.py
+++ b/libcnmc/cir_4_2015/F1.py
@@ -154,25 +154,27 @@ class F1(MultiprocessBased):
         """
         data_ini = '%s-01-01' % (self.year + 1)
         search_params = [('active', '=', True),
+                         ('et', '=', ct_name),
                          '|',
                          ('create_date', '<', data_ini),
                          ('create_date', '=', False)]
 
-        ret_cups_tmp = self.connection.GiscedataCupsPs.search(
+        ret_cups_ids = self.connection.GiscedataCupsPs.search(
             search_params, 0, 0, False, {'active_test': False})
 
-        ret_cups_data = self.connection.GiscedataCupsPs.read(
-            ret_cups_tmp, ["polisses"])
-
+        ret_cups_tmp = self.connection.GiscedataCupsPs.read(
+            ret_cups_ids, ["polisses"]
+        )
         ret_cups = []
-        for cups in ret_cups_data:
-            if set(cups["polisses"]).intersection(self.modcons_in_year):
+
+        for cups in ret_cups_tmp:
+            if set(cups['polisses']).intersection(self.modcons_in_year):
                 ret_cups.append(cups["id"])
 
         if self.generate_derechos:
             cups_derechos_bt = self.get_derechos(TARIFAS_BT, 2)
             cups_derechos_at = self.get_derechos(TARIFAS_AT, 4)
-            return set(cups_derechos_bt + cups_derechos_at)
+            return list(set(ret_cups + cups_derechos_at + cups_derechos_bt))
         else:
             return ret_cups
 

--- a/libcnmc/cir_4_2015/F1.py
+++ b/libcnmc/cir_4_2015/F1.py
@@ -32,20 +32,26 @@ class F1(MultiprocessBased):
         self.base_object = 'CUPS'
         self.report_name = 'F1 - CUPS'
         self.reducir_cups = kwargs.get("reducir_cups", False)
-        mod_all_year = self.connection.GiscedataPolissaModcontractual.search([
-            ("data_inici", "<=", "{}-01-01".format(self.year)),
-            ("data_final", ">=", "{}-12-31".format(self.year))],
-            0, 0, False, {"active_test": False}
+        mod_all_year = self.connection.GiscedataPolissaModcontractual.search(
+            [
+                ("data_inici", "<=", "{}-01-01".format(self.year)),
+                ("data_final", ">=", "{}-12-31".format(self.year)),
+                ("tarifa.name", 'not ilike', '%RE%')
+            ], 0, 0, False, {"active_test": False}
         )
         mods_ini = self.connection.GiscedataPolissaModcontractual.search(
-            [("data_inici", ">=", "{}-01-01".format(self.year)),
-            ("data_inici", "<=", "{}-12-31".format(self.year))],
-            0, 0, False, {"active_test": False}
+            [
+                ("data_inici", ">=", "{}-01-01".format(self.year)),
+                ("data_inici", "<=", "{}-12-31".format(self.year)),
+                ("tarifa.name", 'not ilike', '%RE%')
+            ], 0, 0, False, {"active_test": False}
         )
         mods_fi = self.connection.GiscedataPolissaModcontractual.search(
-            [("data_final", ">=", "{}-01-01".format(self.year)),
-            ("data_final", "<=", "{}-12-31".format(self.year))],
-            0, 0, False, {"active_test": False}
+            [
+                ("data_final", ">=", "{}-01-01".format(self.year)),
+                ("data_final", "<=", "{}-12-31".format(self.year)),
+                ("tarifa.name", 'not ilike', '%RE%')
+            ], 0, 0, False, {"active_test": False}
         )
         self.modcons_in_year = set(mods_fi + mods_ini + mod_all_year)
         self.default_o_cod_tfa = None
@@ -166,10 +172,9 @@ class F1(MultiprocessBased):
         if self.generate_derechos:
             cups_derechos_bt = self.get_derechos(TARIFAS_BT, 2)
             cups_derechos_at = self.get_derechos(TARIFAS_AT, 4)
-            return set(cups_derechos_bt +cups_derechos_at)
+            return set(cups_derechos_bt + cups_derechos_at)
         else:
             return ret_cups
-
 
     def get_zona_qualitat(self, codi_ct):
         """
@@ -334,8 +339,6 @@ class F1(MultiprocessBased):
                     polissa = O.GiscedataPolissa.read(
                         polissa_id[0], fields_to_read, context_glob
                     )
-                    if 'RE' in polissa['tarifa'][1]:
-                        continue
                     if polissa['tensio']:
                         o_tensio = format_f(
                             float(polissa['tensio']) / 1000.0, decimals=3)

--- a/libcnmc/cir_4_2015/F1.py
+++ b/libcnmc/cir_4_2015/F1.py
@@ -154,7 +154,6 @@ class F1(MultiprocessBased):
         """
         data_ini = '%s-01-01' % (self.year + 1)
         search_params = [('active', '=', True),
-                         ('et', '=', 'CT-007'),
                          '|',
                          ('create_date', '<', data_ini),
                          ('create_date', '=', False)]
@@ -272,7 +271,7 @@ class F1(MultiprocessBased):
                     'name', 'id_escomesa', 'id_municipi', 'cne_anual_activa',
                     'cne_anual_reactiva', 'cnmc_potencia_facturada', 'et',
                     'polisses', 'potencia_conveni', 'potencia_adscrita',
-                    "node_id", 'et'
+                    "node_id"
                 ]
                 cups = O.GiscedataCupsPs.read(item, fields_to_read)
                 if not cups or not cups.get('name'):
@@ -282,7 +281,6 @@ class F1(MultiprocessBased):
                     o_name = cups['name'][:20]
                 else:
                     o_name = cups['name'][:22]
-                o_et = cups['et']
                 o_codi_ine_mun = ''
                 o_codi_ine_prov = ''
                 o_zona = ''
@@ -486,8 +484,7 @@ class F1(MultiprocessBased):
                     format_f(o_pot_ads, decimals=3),        # Potencia adscrita a la instalacion
                     format_f(o_anual_activa, decimals=3),   # Energia activa anual consumida
                     format_f(o_anual_reactiva, decimals=3), # Energia reactiva anual consumida
-                    o_any_incorporacio,  # Año informacion
-                    o_et
+                    o_any_incorporacio  # Año informacion
                 ])
             except Exception:
                 traceback.print_exc()

--- a/libcnmc/cir_4_2015/F11.py
+++ b/libcnmc/cir_4_2015/F11.py
@@ -261,7 +261,7 @@ class F11(MultiprocessBased):
                 #     ('et', '=', ct['name']),
                 #     ('polissa_polissa.tarifa.name', 'not in', ["RE", "RE12"])
                 # ])
-                cups = get_cups(ct['name'])
+                cups = self.get_cups(ct['name'])
                 o_energia = sum(
                     x['cne_anual_activa']
                     for x in O.GiscedataCupsPs.read(

--- a/libcnmc/cir_4_2015/F11.py
+++ b/libcnmc/cir_4_2015/F11.py
@@ -15,20 +15,26 @@ class F11(MultiprocessBased):
         self.year = kwargs.pop('year', datetime.now().year - 1)
         self.report_name = 'F11 - CTS'
         self.base_object = 'CTS'
-        mod_all_year = self.connection.GiscedataPolissaModcontractual.search([
-            ("data_inici", "<=", "{}-01-01".format(self.year)),
-            ("data_final", ">=", "{}-12-31".format(self.year))],
-            0, 0, False, {"active_test": False}
+        mod_all_year = self.connection.GiscedataPolissaModcontractual.search(
+            [
+                ("data_inici", "<=", "{}-01-01".format(self.year)),
+                ("data_final", ">=", "{}-12-31".format(self.year)),
+                ("tarifa.name", 'not ilike', '%RE%')
+            ], 0, 0, False, {"active_test": False}
         )
         mods_ini = self.connection.GiscedataPolissaModcontractual.search(
-            [("data_inici", ">=", "{}-01-01".format(self.year)),
-             ("data_inici", "<=", "{}-12-31".format(self.year))],
-            0, 0, False, {"active_test": False}
+            [
+                ("data_inici", ">=", "{}-01-01".format(self.year)),
+                ("data_inici", "<=", "{}-12-31".format(self.year)),
+                ("tarifa.name", 'not ilike', '%RE%')
+            ], 0, 0, False, {"active_test": False}
         )
         mods_fi = self.connection.GiscedataPolissaModcontractual.search(
-            [("data_final", ">=", "{}-01-01".format(self.year)),
-             ("data_final", "<=", "{}-12-31".format(self.year))],
-            0, 0, False, {"active_test": False}
+            [
+                ("data_final", ">=", "{}-01-01".format(self.year)),
+                ("data_final", "<=", "{}-12-31".format(self.year)),
+                ("tarifa.name", 'not ilike', '%RE%')
+            ], 0, 0, False, {"active_test": False}
         )
         self.modcons_in_year = set(mods_fi + mods_ini + mod_all_year)
         self.generate_derechos = kwargs.pop("derechos", False)
@@ -254,13 +260,7 @@ class F11(MultiprocessBased):
                 else:
                     o_tipo = ''
                 o_potencia = float(self.get_potencia_trafos(item))
-                # Si s'ha de fer cuadrar amb els cups s'ha de fer servir un
-                # criteri de filtratge igual al de l'F1 per a fer el SUM
 
-                # cups = O.GiscedataCupsPs.search([
-                #     ('et', '=', ct['name']),
-                #     ('polissa_polissa.tarifa.name', 'not in', ["RE", "RE12"])
-                # ])
                 cups = self.get_cups(ct['name'])
                 o_energia = sum(
                     x['cne_anual_activa']

--- a/libcnmc/cir_4_2015/F11.py
+++ b/libcnmc/cir_4_2015/F11.py
@@ -263,7 +263,6 @@ class F11(MultiprocessBased):
                 o_potencia = float(self.get_potencia_trafos(item))
 
                 cups = self.get_cups(ct['name'])
-                o_ncups = len(cups)
                 o_energia = sum(
                     x['cne_anual_activa']
                     for x in O.GiscedataCupsPs.read(
@@ -304,8 +303,7 @@ class F11(MultiprocessBased):
                     o_codi_r1,                          # CODIGO DISTRIBUIDORA
                     o_propietari,                       # PROPIEDAD
                     o_num_max_maquines,                 # NUM MAX MAQUINAS
-                    o_incorporacio,                      # AÑO INFORMACION
-                    o_ncups
+                    o_incorporacio                      # AÑO INFORMACION
                 ])
             except Exception:
                 traceback.print_exc()

--- a/libcnmc/cir_4_2015/F11.py
+++ b/libcnmc/cir_4_2015/F11.py
@@ -203,21 +203,22 @@ class F11(MultiprocessBased):
                          ('create_date', '<', data_ini),
                          ('create_date', '=', False)]
 
-        ret_cups_tmp = self.connection.GiscedataCupsPs.search(
+        ret_cups_ids = self.connection.GiscedataCupsPs.search(
             search_params, 0, 0, False, {'active_test': False})
 
-        ret_cups_data = self.connection.GiscedataCupsPs.read(
-            ret_cups_tmp, ["polisses"])
-
+        ret_cups_tmp = self.connection.GiscedataCupsPs.read(
+            ret_cups_ids, ["polisses"]
+        )
         ret_cups = []
-        for cups in ret_cups_data:
-            if set(cups["polisses"]).intersection(self.modcons_in_year):
+
+        for cups in ret_cups_tmp:
+            if set(cups['polisses']).intersection(self.modcons_in_year):
                 ret_cups.append(cups["id"])
 
         if self.generate_derechos:
             cups_derechos_bt = self.get_derechos(TARIFAS_BT, 2)
             cups_derechos_at = self.get_derechos(TARIFAS_AT, 4)
-            return set(cups_derechos_bt + cups_derechos_at)
+            return list(set(ret_cups + cups_derechos_at + cups_derechos_bt))
         else:
             return ret_cups
 

--- a/libcnmc/cir_4_2015/F11.py
+++ b/libcnmc/cir_4_2015/F11.py
@@ -263,6 +263,7 @@ class F11(MultiprocessBased):
                 o_potencia = float(self.get_potencia_trafos(item))
 
                 cups = self.get_cups(ct['name'])
+                o_ncups = len(cups)
                 o_energia = sum(
                     x['cne_anual_activa']
                     for x in O.GiscedataCupsPs.read(
@@ -303,7 +304,8 @@ class F11(MultiprocessBased):
                     o_codi_r1,                          # CODIGO DISTRIBUIDORA
                     o_propietari,                       # PROPIEDAD
                     o_num_max_maquines,                 # NUM MAX MAQUINAS
-                    o_incorporacio                      # AÑO INFORMACION
+                    o_incorporacio,                      # AÑO INFORMACION
+                    o_ncups
                 ])
             except Exception:
                 traceback.print_exc()

--- a/libcnmc/cir_4_2015/F20.py
+++ b/libcnmc/cir_4_2015/F20.py
@@ -13,20 +13,26 @@ class F20(MultiprocessBased):
         self.reducir_cups = kwargs.get("reducir_cups", False)
         self.report_name = 'F20 - CTS'
         self.base_object = 'CTS'
-        mod_all_year = self.connection.GiscedataPolissaModcontractual.search([
+        mod_all_year = self.connection.GiscedataPolissaModcontractual.search(
+            [
                 ("data_inici", "<=", "{}-01-01".format(self.year)),
-                ("data_final", ">=", "{}-12-31".format(self.year))],
-                0, 0, False, {"active_test": False}
+                ("data_final", ">=", "{}-12-31".format(self.year)),
+                ("tarifa.name", 'not ilike', '%RE%')
+            ], 0, 0, False, {"active_test": False}
                                 )
         mods_ini = self.connection.GiscedataPolissaModcontractual.search(
-                [("data_inici", ">=", "{}-01-01".format(self.year)),
-                 ("data_inici", "<=", "{}-12-31".format(self.year))],
-                0, 0, False, {"active_test": False}
+            [
+                ("data_inici", ">=", "{}-01-01".format(self.year)),
+                ("data_inici", "<=", "{}-12-31".format(self.year)),
+                ("tarifa.name", 'not ilike', '%RE%')
+            ], 0, 0, False, {"active_test": False}
         )
         mods_fi = self.connection.GiscedataPolissaModcontractual.search(
-                [("data_final", ">=", "{}-01-01".format(self.year)),
-                 ("data_final", "<=", "{}-12-31".format(self.year))],
-                0, 0, False, {"active_test": False}
+            [
+                ("data_final", ">=", "{}-01-01".format(self.year)),
+                ("data_final", "<=", "{}-12-31".format(self.year)),
+                ("tarifa.name", 'not ilike', '%RE%')
+            ], 0, 0, False, {"active_test": False}
         )
 
         self.generate_derechos = kwargs.pop("derechos", False)
@@ -80,7 +86,6 @@ class F20(MultiprocessBased):
         cups_derechos = list(set(cups_derechos) - set(cups_eliminar_id))
 
         return cups_derechos
-
 
     def get_sequence(self):
         data_ini = '%s-01-01' % (self.year + 1)
@@ -137,14 +142,6 @@ class F20(MultiprocessBased):
                 cups = o.GiscedataCupsPs.read(
                     item, fields_to_read
                 )
-                search_params = [('cups', '=', cups['id'])]
-                polissa_id = o.GiscedataPolissa.search(
-                    search_params, 0, 1, 'data_alta desc')
-                if polissa_id:
-                    polissa = o.GiscedataPolissa.read(
-                        polissa_id[0], ['tarifa'])
-                    if 'RE' in polissa['tarifa'][1]:
-                        continue
 
                 o_codi_r1 = "R1-"+self.codi_r1
                 if self.reducir_cups:


### PR DESCRIPTION
# Descripcion
- The CUPS were being filtered using the polissa. In some cases the CUPS didn't have a related polissa so the library was not able to filter them properly. Now we use the ModCon to made as it should be.

# Ficheros modificados
- 4/2015:
  - F1
  - F1bis
  - F11
  - F20