### PR TITLE
Añadir lógica en las circulares del 4/2015 para los ids forzados y excluidos.

### DIFF
--- a/libcnmc/cir_4_2015/F1.py
+++ b/libcnmc/cir_4_2015/F1.py
@@ -7,7 +7,7 @@ import traceback
 from libcnmc.utils import CODIS_TARIFA, CODIS_ZONA, CINI_TG_REGEXP, \
     TARIFAS_AT, TARIFAS_BT
 from libcnmc.utils import get_ine, get_comptador, format_f, get_srid,\
-    convert_srid
+    convert_srid, get_total_elements
 from libcnmc.core import MultiprocessBased
 from ast import literal_eval
 
@@ -173,9 +173,9 @@ class F1(MultiprocessBased):
         if self.generate_derechos:
             cups_derechos_bt = self.get_derechos(TARIFAS_BT, 2)
             cups_derechos_at = self.get_derechos(TARIFAS_AT, 4)
-            return list(set(ret_cups + cups_derechos_at + cups_derechos_bt))
-        else:
-            return ret_cups
+            ids = list(set(ret_cups + cups_derechos_at + cups_derechos_bt))
+
+        return get_total_elements(self.connection, "giscedata.cups.ps", ids)
 
     def get_zona_qualitat(self, codi_ct):
         """

--- a/libcnmc/cir_4_2015/F1.py
+++ b/libcnmc/cir_4_2015/F1.py
@@ -173,9 +173,9 @@ class F1(MultiprocessBased):
         if self.generate_derechos:
             cups_derechos_bt = self.get_derechos(TARIFAS_BT, 2)
             cups_derechos_at = self.get_derechos(TARIFAS_AT, 4)
-            ids = list(set(ret_cups + cups_derechos_at + cups_derechos_bt))
+            ret_cups = list(set(ret_cups + cups_derechos_at + cups_derechos_bt))
 
-        return get_total_elements(self.connection, "giscedata.cups.ps", ids)
+        return get_total_elements(self.connection, "giscedata.cups.ps", ret_cups)
 
     def get_zona_qualitat(self, codi_ct):
         """

--- a/libcnmc/cir_4_2015/F10AT.py
+++ b/libcnmc/cir_4_2015/F10AT.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 import traceback
-from libcnmc.utils import format_f, tallar_text
+from libcnmc.utils import format_f, tallar_text, get_total_elements
 from libcnmc.core import MultiprocessBased
 
 
@@ -29,7 +29,9 @@ class F10AT(MultiprocessBased):
         search_params = [('name', '=', '1')]
         fict_line_id = self.connection.GiscedataAtLinia.search(
             search_params, 0, 0, False, {'active_test': False})
-        return lines_id + fict_line_id
+
+        ids = lines_id + fict_line_id
+        return get_total_elements(self.connection, "giscedata.at.linia", ids)
 
     def get_provincia(self, id_prov):
         o = self.connection

--- a/libcnmc/cir_4_2015/F10AT.py
+++ b/libcnmc/cir_4_2015/F10AT.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 import traceback
-from libcnmc.utils import format_f, tallar_text, get_total_elements
+from libcnmc.utils import format_f, tallar_text, get_total_elements_linia
 from libcnmc.core import MultiprocessBased
 
 
@@ -31,7 +31,7 @@ class F10AT(MultiprocessBased):
             search_params, 0, 0, False, {'active_test': False})
 
         ids = lines_id + fict_line_id
-        return get_total_elements(self.connection, "giscedata.at.linia", ids)
+        return ids
 
     def get_provincia(self, id_prov):
         o = self.connection
@@ -78,6 +78,10 @@ class F10AT(MultiprocessBased):
                 search_params += static_search_params
                 ids = o.GiscedataAtTram.search(
                     search_params, 0, 0, False, {'active_test': False})
+
+                # ids = get_total_elements(self.connection, "giscedata.at.tram", ids)
+                ids = get_total_elements_linia(self.connection, "giscedata.at.tram", ids)
+
                 for at in o.GiscedataAtTram.read(ids, fields_to_read):
                     # Coeficient per ajustar longituds de trams
                     coeficient = at['coeficient'] or 1.0

--- a/libcnmc/cir_4_2015/F10AT.py
+++ b/libcnmc/cir_4_2015/F10AT.py
@@ -79,7 +79,6 @@ class F10AT(MultiprocessBased):
                 ids = o.GiscedataAtTram.search(
                     search_params, 0, 0, False, {'active_test': False})
 
-                # ids = get_total_elements(self.connection, "giscedata.at.tram", ids)
                 ids = get_total_elements_linia(self.connection, "giscedata.at.tram", ids)
 
                 for at in o.GiscedataAtTram.read(ids, fields_to_read):

--- a/libcnmc/cir_4_2015/F10BT.py
+++ b/libcnmc/cir_4_2015/F10BT.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 import traceback
-from libcnmc.utils import format_f, tallar_text
+from libcnmc.utils import format_f, tallar_text, get_total_elements
 from libcnmc.core import MultiprocessBased
 
 
@@ -35,8 +35,11 @@ class F10BT(MultiprocessBased):
                           '&', ('active', '=', False),
                                ('data_baixa', '!=', False),
                           ('active', '=', True)]
-        return self.connection.GiscedataBtElement.search(
+
+        ids = self.connection.GiscedataBtElement.search(
             search_params, 0, 0, False, {'active_test': False})
+
+        return get_total_elements(self.connection, "giscedata.bt.element", ids)
 
     def get_tipus_cable(self, id_cable, id_tipus_linia):
         o = self.connection

--- a/libcnmc/cir_4_2015/F11.py
+++ b/libcnmc/cir_4_2015/F11.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 import traceback
 
-from libcnmc.utils import get_ine, format_f, convert_srid, get_srid
+from libcnmc.utils import get_ine, format_f, convert_srid, get_srid, get_total_elements
 from libcnmc.core import MultiprocessBased
 from libcnmc.cir_4_2015.F1 import TARIFAS_AT, TARIFAS_BT
 from shapely import wkt
@@ -53,8 +53,11 @@ class F11(MultiprocessBased):
                           '&', ('active', '=', False),
                                ('data_baixa', '!=', False),
                           ('active', '=', True)]
-        return self.connection.GiscedataCts.search(
+
+        ids = self.connection.GiscedataCts.search(
             search_params, 0, 0, False, {'active_test': False})
+
+        return get_total_elements(self.connection, "giscedata.cts", ids)
 
     def get_node_vertex(self, ct_id):
         O = self.connection

--- a/libcnmc/cir_4_2015/F12.py
+++ b/libcnmc/cir_4_2015/F12.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 import traceback
 
-from libcnmc.utils import format_f
+from libcnmc.utils import format_f, get_total_elements
 from libcnmc.core import MultiprocessBased
 
 
@@ -30,8 +30,11 @@ class F12(MultiprocessBased):
                           '&', ('active', '=', False),
                                ('data_baixa', '!=', False),
                           ('active', '=', True)]
-        return self.connection.GiscedataTransformadorTrafo.search(
+
+        ids = self.connection.GiscedataTransformadorTrafo.search(
             search_params, 0, 0, False, {'active_test': False})
+
+        return get_total_elements(self.connection, "giscedata.transformador.trafo", ids)
 
     def get_node(self, trafo_id):
         """

--- a/libcnmc/cir_4_2015/F12bis.py
+++ b/libcnmc/cir_4_2015/F12bis.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 import traceback
+from libcnmc.utils import get_total_elements
 from libcnmc.core import MultiprocessBased
 
 
@@ -53,8 +54,10 @@ class F12bis(MultiprocessBased):
                           '&', ('active', '=', False),
                                ('data_baixa', '!=', False),
                           ('active', '=', True)]
-        return self.connection.GiscedataCellesCella.search(
+        ids = self.connection.GiscedataCellesCella.search(
             search_params, 0, 0, False, {'active_test': False})
+
+        return get_total_elements(self.connection, "giscedata.celles.cella", ids)
 
     def obtenir_ct(self, ct):
         i = 0

--- a/libcnmc/cir_4_2015/F13.py
+++ b/libcnmc/cir_4_2015/F13.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 import traceback
-from libcnmc.utils import format_f, convert_srid, get_srid
+from libcnmc.utils import format_f, convert_srid, get_srid, get_total_elements
 from libcnmc.core import MultiprocessBased
 
 
@@ -27,8 +27,10 @@ class F13(MultiprocessBased):
                           '&', ('ct_id.active', '=', False),
                                ('ct_id.data_baixa', '!=', False),
                           ('ct_id.active', '=', True)]
-        return self.connection.GiscedataCtsSubestacions.search(
+        ids = self.connection.GiscedataCtsSubestacions.search(
             search_params, 0, 0, False, {'active_test': False})
+
+        return get_total_elements(self.connection, "giscedata.cts.subestacions", ids)
 
     def get_ines(self, ids):
         o = self.connection

--- a/libcnmc/cir_4_2015/F13C.py
+++ b/libcnmc/cir_4_2015/F13C.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from multiprocessing import Manager
 import re
 import traceback
-
+from libcnmc.utils import get_total_elements
 from libcnmc.utils import CODIS_TARIFA, CODIS_ZONA, CINI_TG_REGEXP
 from libcnmc.utils import get_ine, get_comptador
 from libcnmc.core import MultiprocessBased
@@ -40,8 +40,10 @@ class F13c(MultiprocessBased):
                           '&', ('active', '=', False),
                                ('data_baixa', '!=', False),
                           ('active', '=', True)]
-        return self.connection.GiscedataCtsSubestacionsPosicio.search(
+        ids = self.connection.GiscedataCtsSubestacionsPosicio.search(
             search_params, 0, 0, False, {'active_test': False})
+
+        return get_total_elements(self.connection, "giscedata.cts.subestacions.posicio", ids)
 
     def get_tensio(self, sub):
         o = self.connection

--- a/libcnmc/cir_4_2015/F13bis.py
+++ b/libcnmc/cir_4_2015/F13bis.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 import traceback
-from libcnmc.utils import format_f
+from libcnmc.utils import format_f, get_total_elements
 from libcnmc.core import MultiprocessBased
 
 
@@ -15,8 +15,10 @@ class F13bis(MultiprocessBased):
     def get_sequence(self):
         # Revisem que estigui actiu
         search_params = [('active', '!=', False)]
-        return self.connection.GiscedataParcs.search(
+        ids = self.connection.GiscedataParcs.search(
             search_params, 0, 0, False, {'active_test': False})
+
+        return get_total_elements(self.connection, "giscedata.parcs", ids)
 
     def get_subestacio(self, sub_id):
         """

--- a/libcnmc/cir_4_2015/F14.py
+++ b/libcnmc/cir_4_2015/F14.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 import traceback
-from libcnmc.utils import format_f, get_norm_tension
+from libcnmc.utils import format_f, get_norm_tension, get_total_elements
 from libcnmc.core import MultiprocessBased
 
 
@@ -17,9 +17,10 @@ class F14(MultiprocessBased):
             ('reductor', '=', True),
             ('id_estat.cnmc_inventari', '=', True)
         ]
-        return self.connection.GiscedataTransformadorTrafo.search(
+        ids = self.connection.GiscedataTransformadorTrafo.search(
             search_params
         )
+        return get_total_elements(self.connection, "giscedata.transformador.trafo", ids)
 
     def get_estat(self, estat_id):
         o = self.connection

--- a/libcnmc/cir_4_2015/F15.py
+++ b/libcnmc/cir_4_2015/F15.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 import traceback
-from libcnmc.utils import format_f, convert_srid, get_srid, fetch_cts_node
+from libcnmc.utils import format_f, convert_srid, get_srid, fetch_cts_node, get_total_elements
 from libcnmc.utils import fetch_tensions_norm, fetch_mun_ine, fetch_prov_ine
 from libcnmc.core import MultiprocessBased
 from shapely import wkt
@@ -41,7 +41,7 @@ class F15Pos(MultiprocessBased):
         search_params = [("interruptor", "=", "3")]
         ids = pos_model.search(search_params)
 
-        return ids
+        return get_total_elements(self.connection, "giscedata.cts.subestacions.posicio", ids)
 
     def consumer(self):
         """

--- a/libcnmc/cir_4_2015/F16.py
+++ b/libcnmc/cir_4_2015/F16.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 import traceback
 
-from libcnmc.utils import get_ine, format_f, convert_srid, get_srid
+from libcnmc.utils import get_ine, format_f, convert_srid, get_srid, get_total_elements
 from libcnmc.core import MultiprocessBased
 
 
@@ -26,9 +26,11 @@ class F16(MultiprocessBased):
                           '&', ('active', '=', False),
                                ('data_baixa', '!=', False),
                           ('active', '=', True)]
-        return self.connection.GiscedataCondensadors.search(
+        ids = self.connection.GiscedataCondensadors.search(
             search_params, 0, 0, False, {'active_test': False}
         )
+        return get_total_elements(self.connection, "giscedata.condensadors", ids)
+
 
     def get_node_vertex(self, cond_name):
         """

--- a/libcnmc/cir_4_2015/F1bis.py
+++ b/libcnmc/cir_4_2015/F1bis.py
@@ -118,9 +118,9 @@ class F1bis(MultiprocessBased):
         if self.generate_derechos:
             cups_derechos_bt = self.get_derechos(TARIFAS_BT, 2)
             cups_derechos_at = self.get_derechos(TARIFAS_AT, 4)
-            ids = list(set(ret_cups + cups_derechos_at + cups_derechos_bt))
+            ret_cups = list(set(ret_cups + cups_derechos_at + cups_derechos_bt))
 
-        return get_total_elements(self.connection, "giscedata.cups.ps", ids)
+        return get_total_elements(self.connection, "giscedata.cups.ps", ret_cups)
 
     def get_comptador(self, polissa_id):
         o = self.connection

--- a/libcnmc/cir_4_2015/F1bis.py
+++ b/libcnmc/cir_4_2015/F1bis.py
@@ -2,7 +2,7 @@
 from datetime import datetime, timedelta
 import traceback
 
-from libcnmc.utils import get_comptador, format_f, TARIFAS_AT, TARIFAS_BT
+from libcnmc.utils import get_comptador, format_f, TARIFAS_AT, TARIFAS_BT, get_total_elements
 from libcnmc.core import MultiprocessBased
 
 
@@ -118,9 +118,9 @@ class F1bis(MultiprocessBased):
         if self.generate_derechos:
             cups_derechos_bt = self.get_derechos(TARIFAS_BT, 2)
             cups_derechos_at = self.get_derechos(TARIFAS_AT, 4)
-            return list(set(ret_cups + cups_derechos_at + cups_derechos_bt))
-        else:
-            return ret_cups
+            ids = list(set(ret_cups + cups_derechos_at + cups_derechos_bt))
+
+        return get_total_elements(self.connection, "giscedata.cups.ps", ids)
 
     def get_comptador(self, polissa_id):
         o = self.connection

--- a/libcnmc/cir_4_2015/F20.py
+++ b/libcnmc/cir_4_2015/F20.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 import traceback
 from libcnmc.core import MultiprocessBased
-from libcnmc.utils import TARIFAS_BT, TARIFAS_AT
+from libcnmc.utils import TARIFAS_BT, TARIFAS_AT, get_total_elements
 
 
 class F20(MultiprocessBased):
@@ -110,9 +110,9 @@ class F20(MultiprocessBased):
         if self.generate_derechos:
             cups_derechos_bt = self.get_derechos(TARIFAS_BT, 2)
             cups_derechos_at = self.get_derechos(TARIFAS_AT, 4)
-            return list(set(ret_cups + cups_derechos_at + cups_derechos_bt))
-        else:
-            return ret_cups
+            ids = list(set(ret_cups + cups_derechos_at + cups_derechos_bt))
+
+        return get_total_elements(self.connection, "giscedata.cups.ps", ids)
 
     def get_cini(self, et):
         o = self.connection

--- a/libcnmc/cir_4_2015/F20.py
+++ b/libcnmc/cir_4_2015/F20.py
@@ -110,9 +110,9 @@ class F20(MultiprocessBased):
         if self.generate_derechos:
             cups_derechos_bt = self.get_derechos(TARIFAS_BT, 2)
             cups_derechos_at = self.get_derechos(TARIFAS_AT, 4)
-            ids = list(set(ret_cups + cups_derechos_at + cups_derechos_bt))
+            ret_cups = list(set(ret_cups + cups_derechos_at + cups_derechos_bt))
 
-        return get_total_elements(self.connection, "giscedata.cups.ps", ids)
+        return get_total_elements(self.connection, "giscedata.cups.ps", ret_cups)
 
     def get_cini(self, et):
         o = self.connection

--- a/libcnmc/utils.py
+++ b/libcnmc/utils.py
@@ -68,6 +68,56 @@ def get_total_elements(connection, model, ids):
     return list(set(ids))
 
 
+def get_total_elements_linia(connection, model, ids):
+    """
+        Returns the force include and force exclude ids of elements
+        :param connection:
+        :param model:
+
+        :return:Included and excluded elements
+        :rtype: dict(str,list)
+        """
+    c = connection
+    try:
+        mod_obj = getattr(c, c.normalize_model_name(model))
+    except Exception:
+        mod_obj = c.model(model)
+
+    include_search_params = [
+        ("criteri_regulatori", "=", "incloure"),
+        ("id", "in", ids)
+    ]
+    include_ids = mod_obj.search(
+        include_search_params, False, False, False, {'active_test': False}
+    )
+
+    include_search_params = [
+        ("criteri_regulatori", "=", "excloure"),
+        ("id", "in", ids)
+    ]
+    exclude_ids = mod_obj.search(
+        include_search_params, False, False, False, {'active_test': False}
+    )
+
+    forced_ids = {
+        "include": include_ids,
+        "exclude": exclude_ids
+    }
+
+    ids = ids + forced_ids["include"]
+    ids_excluded = forced_ids["exclude"]
+    if len(forced_ids["include"]) > 0:
+        print "included: "
+        print forced_ids["include"]
+    if len(forced_ids["exclude"]) > 0:
+        print "exclude: "
+        print forced_ids["exclude"]
+
+    ids = list(set(ids) - set(ids_excluded))
+
+    return list(set(ids))
+
+
 def get_forced_elements(connection, model):
     """
     Returns the force include and force exclude ids of elements

--- a/libcnmc/utils.py
+++ b/libcnmc/utils.py
@@ -48,6 +48,26 @@ TARIFAS_BT = [
 ]
 
 
+def get_total_elements(connection, model, ids):
+    """
+    Returns the list of force, excluded and regular ids of elements
+    :param connection:
+    :param model: model of elements
+    :type: str
+    :param ids: list of regular ids
+    :type: list
+    :return: list of excluded, forced and regular ids
+    :rtype: list
+    """
+    forced_ids = get_forced_elements(connection, model)
+
+    ids = ids + forced_ids["include"]
+    ids_excluded = forced_ids["exclude"]
+    ids = list(set(ids) - set(ids_excluded))
+
+    return list(set(ids))
+
+
 def get_forced_elements(connection, model):
     """
     Returns the force include and force exclude ids of elements


### PR DESCRIPTION
# Descripción
- Añadir lógica para controlar los ids marcados como forzados o excluidos en sus formularios

# Ficheros modificados
- libcnmc/cir_4_2015/F1.py
- libcnmc/cir_4_2015/F10AT.py
- libcnmc/cir_4_2015/F10BT.py
- libcnmc/cir_4_2015/F11.py
- libcnmc/cir_4_2015/F12.py
- libcnmc/cir_4_2015/F12bis.py
- libcnmc/cir_4_2015/F13.py
- libcnmc/cir_4_2015/F13C.py
- libcnmc/cir_4_2015/F13bis.py
- libcnmc/cir_4_2015/F14.py
- libcnmc/cir_4_2015/F15.py
- libcnmc/cir_4_2015/F16.py
- libcnmc/cir_4_2015/F1bis.py
- libcnmc/cir_4_2015/F20.py
- libcnmc/utils.py
