### PR TITLE
Excluir salidas INT_BT del F11-4/2015

### DIFF
--- a/libcnmc/cir_4_2015/F11.py
+++ b/libcnmc/cir_4_2015/F11.py
@@ -100,8 +100,9 @@ class F11(MultiprocessBased):
         utilitzades = 0
 
         try:
+            id_intbt = O.GiscedataBtQuadreElementTipus.search([("code", "=", "INT_BT")])
             quadres_bt_ids = O.GiscedataBtQuadreElement.search(
-                [("ct_id", "=", ct_id)]
+                [("ct_id", "=", ct_id),("blockname", "!=", id_intbt)]
             )
 
             disponibles = len(quadres_bt_ids)


### PR DESCRIPTION
# Descripcion
- En los F11 de la 4/2015 excluir de las salidas de los CTs los interruptores del tipo "INT_BT"

# Ficheros modificados
- F11.py