### PR TITLE
Utilizar campo 4666_entregada único.

### DIFF
--- a/libcnmc/cli_4666.py
+++ b/libcnmc/cli_4666.py
@@ -240,8 +240,7 @@ def res_4666_lat(**kwargs):
     """
 
     from libcnmc.res_4666 import LAT
-    last_year = kwargs["year"] - 1
-    kwargs["compare_field"] = "4666_entregada_{}".format(last_year)
+    kwargs["compare_field"] = "4666_entregada"
     res_lat(LAT, **kwargs)
 
 
@@ -280,8 +279,7 @@ def res_4666_lbt(**kwargs):
     """
 
     from libcnmc.res_4666 import LBT
-    last_year = kwargs["year"] - 1
-    kwargs["compare_field"] = "4666_entregada_{}".format(last_year)
+    kwargs["compare_field"] = "4666_entregada"
     res_lat(LBT, **kwargs)
 
 
@@ -319,8 +317,7 @@ def res_4666_cts(**kwargs):
     """
 
     from libcnmc.res_4666 import CTS
-    last_year = kwargs["year"] - 1
-    kwargs["compare_field"] = "4666_entregada_{}".format(last_year)
+    kwargs["compare_field"] = "4666_entregada"
     res_lat(CTS, **kwargs)
 
 
@@ -356,8 +353,7 @@ def res_4666_sub(**kwargs):
     """
 
     from libcnmc.res_4666 import SUB
-    last_year = kwargs["year"] - 1
-    kwargs["compare_field"] = "4666_entregada_{}".format(last_year)
+    kwargs["compare_field"] = "4666_entregada"
     res_lat(SUB, **kwargs)
 
 
@@ -395,8 +391,7 @@ def res_4666_pos(**kwargs):
     """
 
     from libcnmc.res_4666 import POS, POS_INT
-    last_year = kwargs["year"] - 1
-    kwargs["compare_field"] = "4666_entregada_{}".format(last_year)
+    kwargs["compare_field"] = "4666_entregada"
     res_pos2(POS, POS_INT, **kwargs)
 
 
@@ -432,8 +427,7 @@ def res_4666_maq(**kwargs):
     """
 
     from libcnmc.res_4666 import MAQ
-    last_year = kwargs["year"] - 1
-    kwargs["compare_field"] = "4666_entregada_{}".format(last_year)
+    kwargs["compare_field"] = "4666_entregada"
     res_lat(MAQ, **kwargs)
 
 
@@ -469,8 +463,7 @@ def res_4666_des(**kwargs):
     """
 
     from libcnmc.res_4666 import DES
-    last_year = kwargs["year"] - 1
-    kwargs["compare_field"] = "4666_entregada_{}".format(last_year)
+    kwargs["compare_field"] = "4666_entregada"
     res_lat(DES, **kwargs)
 
 
@@ -508,8 +501,7 @@ def res_4666_fia(**kwargs):
     :rtype: None 
     """
     from libcnmc.res_4666 import FIA
-    last_year = kwargs["year"] - 1
-    kwargs["compare_field"] = "4666_entregada_{}".format(last_year)
+    kwargs["compare_field"] = "4666_entregada"
     res_lat(FIA, **kwargs)
 
 
@@ -545,8 +537,7 @@ def res_4666_con(**kwargs):
     """
 
     from libcnmc.res_4666 import CON
-    last_year = kwargs["year"] - 1
-    kwargs["compare_field"] = "4666_entregada_{}".format(last_year)
+    kwargs["compare_field"] = "4666_entregada"
     res_lat(CON, **kwargs)
 
 
@@ -573,8 +564,7 @@ def res_4666_con(**kwargs):
 @click.option('--num-proc', default=N_PROC, type=click.INT)
 def aud_4666_lat(**kwargs):
     from libcnmc.res_4666.AUD_LAT import LAT
-    last_year = kwargs["year"] - 1
-    kwargs["compare_field"] = "4666_entregada_{}".format(last_year)
+    kwargs["compare_field"] = "4666_entregada"
     res_lat(LAT, **kwargs)
 
 
@@ -601,8 +591,7 @@ def aud_4666_lat(**kwargs):
 @click.option('--num-proc', default=N_PROC, type=click.INT)
 def aud_4666_lbt(**kwargs):
     from libcnmc.res_4666.AUD_LBT import LBT
-    last_year = kwargs["year"] - 1
-    kwargs["compare_field"] = "4666_entregada_{}".format(last_year)
+    kwargs["compare_field"] = "4666_entregada"
     res_lat(LBT, **kwargs)
 
 
@@ -629,8 +618,7 @@ def aud_4666_lbt(**kwargs):
 @click.option('--num-proc', default=N_PROC, type=click.INT)
 def aud_4666_cts(**kwargs):
     from libcnmc.res_4666.AUD_CTS import CTS
-    last_year = kwargs["year"] - 1
-    kwargs["compare_field"] = "4666_entregada_{}".format(last_year)
+    kwargs["compare_field"] = "4666_entregada"
     res_lat(CTS, **kwargs)
 
 
@@ -657,8 +645,7 @@ def aud_4666_cts(**kwargs):
 @click.option('--num-proc', default=N_PROC, type=click.INT)
 def aud_4666_pos(**kwargs):
     from libcnmc.res_4666.AUD_POS import POS, POS_INT
-    last_year = kwargs["year"] - 1
-    kwargs["compare_field"] = "4666_entregada_{}".format(last_year)
+    kwargs["compare_field"] = "4666_entregada"
     res_pos2(POS, POS_INT, **kwargs)
 
 
@@ -685,7 +672,6 @@ def aud_4666_pos(**kwargs):
 @click.option('--num-proc', default=N_PROC, type=click.INT)
 def aud_4666_fia(**kwargs):
     from libcnmc.res_4666.AUD_FIA import FIA
-    last_year = kwargs["year"] - 1
-    kwargs["compare_field"] = "4666_entregada_{}".format(last_year)
+    kwargs["compare_field"] = "4666_entregada"
     res_lat(FIA, **kwargs)
 


### PR DESCRIPTION
# Descripcion
- Eliminar años de la comparativa de datos entregados para el 4666. Comparar con campo único.