### PR TITLE
Corregir la generacion del F9 de la 4/2015 en los casos donde se tenia que transformar las coordenades de SRID

### DIFF
--- a/libcnmc/utils.py
+++ b/libcnmc/utils.py
@@ -465,9 +465,9 @@ def parse_geom(geom):
     if geom:
         points = [
             {
-                'x': str(x[0]).replace('.', ','),
-                'y': str(x[1]).replace('.', ',')
-            } for x in wkt.loads(geom).coords
+                'x': coord[0],
+                'y': coord[1]
+            } for coord in wkt.loads(geom).coords
         ]
     else:
         points = []


### PR DESCRIPTION
# Descripcion

- Don't cast coords to string since it's done after and it breaks the pyproj transform method because we also replace dots by commas.


# Ficheros modificados
- 4/2015: F9