### PR TITLE
Fijar versión de "pyproj" en los requerimientos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ progressbar<=2.3
 click<7.0
 libcomxml
 chardet
-pyproj
+pyproj=2.2.2
 osconf
 cerberus>=1.0
 python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ progressbar<=2.3
 click<7.0
 libcomxml
 chardet
-pyproj=2.2.2
+pyproj==2.2.2
 osconf
 cerberus>=1.0
 python-dateutil


### PR DESCRIPTION
# Descripcion
- Fijar la versión de la librería `pyproj` en las dependencias, para evitar problemas e incompatibilidades.

# Ficheros modificados
- `requirements.txt`