### PR TITLE
IMP A1 Obtener el último autoconsumo_id del año

### DIFF
--- a/libcnmc/cir_8_2021/FA1.py
+++ b/libcnmc/cir_8_2021/FA1.py
@@ -437,10 +437,13 @@ class FA1(StopMultiprocessBased):
                 o_cod_generacio_auto = ''
                 o_conexion_autoconsumo = ''
 
-                if cups.get('autoconsum_id', False):
+                cups_obj = O.GiscedataCupsPs
+                autoconsum_id_data = cups_obj.get_autoconsum_on_date(item, ultim_dia_any)
+
+                if autoconsum_id_data:
                     # AUTOCONSUMO
                     o_autoconsumo = 1
-                    autoconsum_id = cups['autoconsum_id'][0]
+                    autoconsum_id = autoconsum_id_data[0]
                     autoconsum_data = O.GiscedataAutoconsum.read(autoconsum_id, ['cau', 'tipus_autoconsum',
                                                                                  'generador_id', 'codi_cnmc'])
                     # CAU


### PR DESCRIPTION
# Descripcion
- Ahora busca el "autoconsum_id" de un CUPS utilizando la funcion "get_autoconsum_on_date". De esta manera se obtiene el autoconsumo del CUPS en una fecha determinada y no el "autoconsum_id" actual.

# Ficheros modificados
- A1
