### PR TITLE
FIX Mejora el cálculo de estado_contrato en el A1 - Cir8/2021

### DIFF
--- a/libcnmc/cir_8_2021/FA1.py
+++ b/libcnmc/cir_8_2021/FA1.py
@@ -526,7 +526,19 @@ class FA1(StopMultiprocessBased):
                 o_potencia = ''
                 o_cnae = ''
                 o_cod_tfa = ''
-                o_estat_contracte = 0
+
+                # ESTADO CONTRATO
+                contracte_obj = O.GiscedataPolissaModcontractual
+                date_mod = '{}-12-31'.format(self.year)
+                search_params = [('data_inici', '<=', date_mod),
+                                 ('data_final', '>=', date_mod),
+                                 ('polissa_id.id', '=', polissa_id)]
+                id_modcon = contracte_obj.search(search_params, limit=1, context={'active_test': False})
+                if id_modcon:
+                    o_estat_contracte = 0
+                else:
+                    o_estat_contracte = 1
+
                 # energies consumides
                 o_anual_activa = format_f(
                     cups['cne_anual_activa'] or 0.0, decimals=3)

--- a/libcnmc/cir_8_2021/FA1.py
+++ b/libcnmc/cir_8_2021/FA1.py
@@ -533,8 +533,8 @@ class FA1(StopMultiprocessBased):
                 search_params = [('data_inici', '<=', date_mod),
                                  ('data_final', '>=', date_mod),
                                  ('polissa_id.id', '=', polissa_id)]
-                id_modcon = contracte_obj.search(search_params, limit=1, context={'active_test': False})
-                if id_modcon:
+                modcon_id = contracte_obj.search(search_params, limit=1, context={'active_test': False})
+                if modcon_id:
                     o_estat_contracte = 0
                 else:
                     o_estat_contracte = 1
@@ -608,7 +608,6 @@ class FA1(StopMultiprocessBased):
                 else:
                     o_comptador_cini = ''
                     o_comptador_data = ''
-                    o_estat_contracte = 1
 
                     search_modcon = [
                         ('id', 'in', cups['polisses']),


### PR DESCRIPTION
# Descripcion
- Ahora el estado_contrato se calcula únicamente comprobando si existía una modcon en fecha del 'año_formulario-12-31'

# Ficheros modificados
- A1
