### PR TITLE
ADD Lee si hay algún CUPS de SSAA vinculado al RECORE A2 - Cir8/2021

### DIFF
--- a/libcnmc/cir_8_2021/FA2.py
+++ b/libcnmc/cir_8_2021/FA2.py
@@ -124,24 +124,27 @@ class FA2(StopMultiprocessBased):
                 res['cau'] = cau_data['cau']
         return res
 
-    def get_serveis_aux(self, cups, item):
+    def get_serveis_aux(self, cups_serveis_aux_id, cups, item):
         o = self.connection
         serveis_aux = ''
 
-        polissa_obj = o.GiscedataPolissa
-        polissa_id = polissa_obj.search([('re_installation_id', '=', item)])
-        if polissa_id:
-            polissa_data = polissa_obj.read(polissa_id[0], ['cups'])
-            if polissa_data.get('cups', False):
-                serveis_aux = polissa_data['cups'][1]
+        if cups_serveis_aux_id:
+            serveis_aux = cups_serveis_aux_id[1]
         else:
-            cups_20 = cups[1][0:20]
-            cups_id = o.GiscedataCupsPs.search([('name', 'ilike', cups_20), ('name', '!=', cups)])
-            if cups_id:
-                cups_name = o.GiscedataCupsPs.read(cups_id, ['name'])
-                if cups_name:
-                    if cups_name[0].get('name', False):
-                        serveis_aux = cups_name[0]['name']
+            polissa_obj = o.GiscedataPolissa
+            polissa_id = polissa_obj.search([('re_installation_id', '=', item)])
+            if polissa_id:
+                polissa_data = polissa_obj.read(polissa_id[0], ['cups'])
+                if polissa_data.get('cups', False):
+                    serveis_aux = polissa_data['cups'][1]
+            else:
+                cups_20 = cups[1][0:20]
+                cups_id = o.GiscedataCupsPs.search([('name', 'ilike', cups_20), ('name', '!=', cups)])
+                if cups_id:
+                    cups_name = o.GiscedataCupsPs.read(cups_id, ['name'])
+                    if cups_name:
+                        if cups_name[0].get('name', False):
+                            serveis_aux = cups_name[0]['name']
 
         return serveis_aux
 
@@ -160,7 +163,7 @@ class FA2(StopMultiprocessBased):
 
     def consumer(self):
         o = self.connection
-        fields_to_read = ['provincia', 'cini', 'cups', 'potencia_nominal', 'cil']
+        fields_to_read = ['provincia', 'cini', 'cups', 'potencia_nominal', 'cil', 'cups_serveis_aux_id']
         while True:
             try:
                 item = self.input_q.get()
@@ -244,7 +247,10 @@ class FA2(StopMultiprocessBased):
                 o_cau = autoconsum['cau']
 
                 # Serveis auxiliars
-                o_cups_servicios_auxiliares = self.get_serveis_aux(cups, item)
+                cups_serveis_aux_id = ''
+                if recore.get('cups_serveis_aux_id', False):
+                    cups_serveis_aux_id = recore['cups_serveis_aux_id']
+                o_cups_servicios_auxiliares = self.get_serveis_aux(cups_serveis_aux_id, cups, item)
 
                 self.output_q.put([
                     o_nudo,  # Node


### PR DESCRIPTION
# Descripcion
- A2, campo CUPS_SERVICIOS_AUXILIARES. Lee si hay algún CUPS de SSAA vinculado al RECORE, si es el caso la usa, si no lo busca en la póliza y si la póliza tampoco lo contiene busca un CUPS que coincida con el de la instalación.

requires https://github.com/gisce/erp/pull/16503

# Ficheros modificados
- A2
