### PR TITLE
ADD Genera el CIL a partir del CUPS - A2 - Cir8/2021

### DIFF
--- a/libcnmc/cir_8_2021/FA2.py
+++ b/libcnmc/cir_8_2021/FA2.py
@@ -200,7 +200,7 @@ class FA2(StopMultiprocessBased):
                     )
 
                 # CIL
-                o_cil = '{}{}'.format(cups, '001')
+                o_cil = '{}{}'.format(cups[1], '001')
 
                 # CINI
                 o_cini = ''


### PR DESCRIPTION
# Descripcion
- Genera el CIL a partir del CUPS - Cir8/2021
- Añade '001' al CUPS

# Ficheros modificados
- A2
