### PR TITLE
IMP Mejoras en B3 y B3.1 - Cir8/2021

### DIFF
--- a/libcnmc/cir_8_2021/FB3.py
+++ b/libcnmc/cir_8_2021/FB3.py
@@ -30,7 +30,8 @@ class FB3(StopMultiprocessBased):
     def get_sequence(self):
         data_pm = '%s-01-01' % (self.year + 1)
         data_baixa = '%s-12-31' % self.year
-        search_params = ['|', ('ct_id.data_pm', '=', False),
+        search_params = [('criteri_regulatori', '!=', 'excloure'),
+                         '|', ('ct_id.data_pm', '=', False),
                          ('ct_id.data_pm', '<', data_pm),
                          '|', ('ct_id.data_baixa', '>', data_baixa),
                          ('ct_id.data_baixa', '=', False),

--- a/libcnmc/cir_8_2021/FB3_1.py
+++ b/libcnmc/cir_8_2021/FB3_1.py
@@ -23,7 +23,8 @@ class FB3_1(StopMultiprocessBased):
 
     def get_sequence(self):
         # Revisem que estigui actiu
-        search_params = [('active', '!=', False)]
+        search_params = [('criteri_regulatori', '!=', 'excloure'),
+                         ('active', '!=', False)]
         return self.connection.GiscedataParcs.search(
             search_params, 0, 0, False, {'active_test': False})
 

--- a/libcnmc/cir_8_2021/FB3_1.py
+++ b/libcnmc/cir_8_2021/FB3_1.py
@@ -117,6 +117,7 @@ class FB3_1(StopMultiprocessBased):
                 o_tensio_const = parc['tensio_const']
 
                 if o_tensio_const:
+                    o_tensio_const = o_tensio_const[1]
                     if tensio != o_tensio_const:
                         o_tensio_const = format_f(
                             float(o_tensio_const) / 1000.0, decimals=3)


### PR DESCRIPTION
# Descripcion
- Excluye los registros con criterio_regulatorio = excluir
- Corrige un error al leer 'tensio_const'

# Ficheros modificados
- B3, B3.1
