### PR TITLE
IMP Excluye los IDs que tengan criterio regulatorio = Excluir en B2.2 - Cir8/2021

### DIFF
--- a/libcnmc/cir_8_2021/FB2_2.py
+++ b/libcnmc/cir_8_2021/FB2_2.py
@@ -55,7 +55,8 @@ class FB2_2(StopMultiprocessBased):
 
         data_pm = '{}-01-01'.format(self.year + 1)
         data_baixa = '{}-12-31'.format(self.year)
-        search_params += ['|', ('data_pm', '=', False),
+        search_params += [('criteri_regulatori', '!=', 'excloure'),
+                          '|', ('data_pm', '=', False),
                           ('data_pm', '<', data_pm),
                           '|', ('data_baixa', '>', data_baixa),
                           ('data_baixa', '=', False)


### PR DESCRIPTION
# Descripcion
- Excluye los IDs que tengan criterio regulatorio = Excluir

# Ficheros modificados
- B2.2
