### PR TITLE
IMP OPERACION vacío cuando MODELO = M - B1 - Cir8/2021

### DIFF
--- a/libcnmc/cir_8_2021/FB1.py
+++ b/libcnmc/cir_8_2021/FB1.py
@@ -466,6 +466,7 @@ class FB1(StopMultiprocessBased):
                     if modelo == 'M':
                         estado = ''
                         fecha_aps = ''
+                        operacion = ''
                     else:
                         # Estado
                         if tram[self.compare_field]:


### PR DESCRIPTION
# Descripcion
-  OPERACION vacío cuando MODELO = M según el validador

# Ficheros modificados
- B1
