### PR TITLE
Omitir casos erróneos - D2 Circular 8/2021

### DIFF
--- a/libcnmc/cir_8_2021/FD2.py
+++ b/libcnmc/cir_8_2021/FD2.py
@@ -561,6 +561,7 @@ class FD2(StopMultiprocessBased):
                             'errors': erros_msg,
                         }
                         self.create_logs(create_vals, ref)
+                        continue
 
                     invoice_id = o.GiscedataFacturacioFactura.read(fact_id, ['invoice_id'])['invoice_id'][0]
                     model_names = ['giscedata.switching.c1.05', 'account.invoice']
@@ -581,6 +582,7 @@ class FD2(StopMultiprocessBased):
                 c2_header_id = o.model("giscedata.switching.c2.05").read(c205_id, ['header_id'])[
                     'header_id']
                 sw_id = o.GiscedataSwitchingStepHeader.read(c2_header_id[0], ['sw_id'])['sw_id'][0]
+                ref = ('giscedata.switching', sw_id)
                 step_id = o.GiscedataSwitching.read(sw_id, ['step_id'])['step_id'][0]
                 proces_name = o.model('giscedata.switching.step').read(step_id, ['name'])['name']
                 if '05' in proces_name:
@@ -591,6 +593,15 @@ class FD2(StopMultiprocessBased):
                     fact_id = o.GiscedataPolissa.get_last_invoice_by_partner(polissa_id, comer_sortint_id,
                                                                              {'data_act': data_act})
                     if not fact_id:
+                        erros_msg = "Error, no s'ha trobat l'última factura de la comer: " + str(
+                            comer_sortint_id) + "en data: " + str(data_act)
+                        create_vals = {
+                            'cod_gestio_id': cod_gest_data['name'],
+                            'atesa': False,
+                            'on_time': False,
+                            'errors': erros_msg,
+                        }
+                        self.create_logs(create_vals, ref)
                         continue
                     invoice_id = o.GiscedataFacturacioFactura.read(fact_id, ['invoice_id'])['invoice_id'][0]
                     model_names = ['giscedata.switching.c2.05', 'account.invoice']


### PR DESCRIPTION
# Descripcion
- Se ha añadido la omision de los casos con errores de datos despues de registrarlos para su futura revisión

# Ficheros modificados
- D2
