### PR TITLE
FIX Corrige el sequence del B1.1 - Cir8/2021

### DIFF
--- a/libcnmc/cir_8_2021/FB1_1.py
+++ b/libcnmc/cir_8_2021/FB1_1.py
@@ -16,11 +16,11 @@ class FB1_1(StopMultiprocessBased):
 
     def get_sequence(self):
         data_pm = '%s-01-01' % (self.year + 1)
-        data_baixa = '%s-12-31' % self.year
+        data_baixa = '%s-01-01' % self.year
         search_params = [('criteri_regulatori', '!=', 'excloure'),
                          '|', ('data_pm', '=', False),
                          ('data_pm', '<', data_pm),
-                         '|', ('data_baixa', '>', data_baixa),
+                         '|', ('data_baixa', '>=', data_baixa),
                          ('data_baixa', '=', False),
                          ]
         # Revisem que si està de baixa ha de tenir la data informada.


### PR DESCRIPTION
# Descripcion
- Corrige el sequence del B1.1 ya que no mostraba elementos de baja durante el año del formulario.

# Ficheros modificados
- B1.1
