### PR TITLE
IMP Vacía el valor de las subenciones PRTR para el ejercicio 2022 - Cir8/2021

### DIFF
--- a/libcnmc/cir_8_2021/FB1.py
+++ b/libcnmc/cir_8_2021/FB1.py
@@ -492,6 +492,9 @@ class FB1(StopMultiprocessBased):
                             motivacion = ''
                             tipo_inversion = ''
 
+                        # L'any 2022 no es declaren subvencions PRTR
+                        subvenciones_prtr = ''
+
                     output = [
                         o_tram,  # IDENTIFICADOR
                         tram.get('cini', '') or '',         # CINI
@@ -845,6 +848,9 @@ class FB1(StopMultiprocessBased):
                         if fecha_baja:
                             motivacion = ''
                             tipo_inversion = ''
+
+                    # L'any 2022 no es declaren subvencions PRTR
+                    subvenciones_prtr = ''
 
                     output = [
                         identificador_tramo,  # IDENTIFICADOR TRAMO

--- a/libcnmc/cir_8_2021/FB2.py
+++ b/libcnmc/cir_8_2021/FB2.py
@@ -393,6 +393,9 @@ class FB2(StopMultiprocessBased):
                 if fecha_baja:
                     tipo_inversion = ''
 
+                # L'any 2022 no es declaren subvencions PRTR
+                subvenciones_prtr = ''
+
                 output = [
                     o_identificador_ct,           # IDENTIFICADOR
                     ct['cini'] or '',                   # CINI

--- a/libcnmc/cir_8_2021/FB4.py
+++ b/libcnmc/cir_8_2021/FB4.py
@@ -328,6 +328,9 @@ class FB4(StopMultiprocessBased):
                 if fecha_baja:
                     tipo_inversion = ''
 
+                # L'any 2022 no es declaren subvencions PRTR
+                subvenciones_prtr = ''
+
                 output = [
                     pos['name'],  #IDENTIFICADOR_POSICION
                     pos['cini'],  #CINI

--- a/libcnmc/cir_8_2021/FB5.py
+++ b/libcnmc/cir_8_2021/FB5.py
@@ -256,6 +256,9 @@ class FB5(StopMultiprocessBased):
                 if fecha_baja:
                     tipo_inversion = ''
 
+                # L'any 2022 no es declaren subvencions PRTR
+                subvenciones_prtr = ''
+
                 self.output_q.put([
                     o_maquina,              # IDENTIFICADOR_MAQUINA
                     o_cini,                 # CINI

--- a/libcnmc/cir_8_2021/FB6.py
+++ b/libcnmc/cir_8_2021/FB6.py
@@ -445,6 +445,9 @@ class FB6(StopMultiprocessBased):
                 if causa_baja in [1, 3]:
                     tipo_inversion = ''
 
+                # L'any 2022 no es declaren subvencions PRTR
+                subvenciones_prtr = ''
+
                 self.output_q.put([
                     o_fiabilitat,   # ELEMENTO FIABILIDAD
                     o_cini,  # CINI

--- a/libcnmc/cir_8_2021/FB8.py
+++ b/libcnmc/cir_8_2021/FB8.py
@@ -200,6 +200,9 @@ class FB8(StopMultiprocessBased):
                 else:
                     descripcio = ''
 
+                # L'any 2022 no es declaren subvencions PRTR
+                subvenciones_prtr = ''
+
                 self.output_q.put([
                     despatx['name'],                    # IDENTIFICADOR
                     despatx['cini'],                    # CINI


### PR DESCRIPTION
# Descripcion
- Vacía el valor de las subenciones PRTR para el ejercicio 2022

# Ficheros modificados
- B1, B2, B4, B5, B6, B8
