### PR TITLE
IMP Mejora el importador del inventario 4666 para buscar según name y id_regulatorio - Cir8/2021

### DIFF
--- a/libcnmc/models/cnmcmodel.py
+++ b/libcnmc/models/cnmcmodel.py
@@ -56,11 +56,11 @@ class CNMCModel(object):
         """
         self.validator = CNMCValidator(self.schema)
         stored = namedtuple('{0}_store'.format(self.__class__.__name__), self.fields)
+        self.trams_at_prefix = kwvalues.pop('trams_at_prefix') or ''
+        self.trams_bt_prefix = kwvalues.pop('trams_bt_prefix') or ''
         self.store = stored(*values, **kwvalues)
         self.validator.validate(self.store._asdict())
         self.store = stored(**self.validator.document)
-        self.trams_at_prefix = kwvalues.get('trams_at_prefix', False) or ''
-        self.trams_bt_prefix = kwvalues.get('trams_bt_prefix', False) or ''
 
     def dump(self, out_format='json'):
         if out_format == 'json':

--- a/libcnmc/models/cnmcmodel.py
+++ b/libcnmc/models/cnmcmodel.py
@@ -59,6 +59,8 @@ class CNMCModel(object):
         self.store = stored(*values, **kwvalues)
         self.validator.validate(self.store._asdict())
         self.store = stored(**self.validator.document)
+        self.trams_at_prefix = kwvalues.get('trams_at_prefix', False) or ''
+        self.trams_bt_prefix = kwvalues.get('trams_bt_prefix', False) or ''
 
     def dump(self, out_format='json'):
         if out_format == 'json':

--- a/libcnmc/models/res_4666/f1_4666.py
+++ b/libcnmc/models/res_4666/f1_4666.py
@@ -3,6 +3,7 @@ from libcnmc.models.cnmcmodel import CNMCModel
 from collections import OrderedDict
 from libcnmc.models.fields import String, Integer, Decimal
 import string
+import re
 
 
 class F1Res4666(CNMCModel):
@@ -32,9 +33,7 @@ class F1Res4666(CNMCModel):
 
     @property
     def ref(self):
-        return ''.join(
-            c for c in self.store.identificador if c in string.digits
-        )
+        return re.sub('^{}'.format(self.trams_at_prefix), '', self.store.identificador)
 
     def __cmp__(self, other):
         comp_fields = [

--- a/libcnmc/models/res_4666/f2_4666.py
+++ b/libcnmc/models/res_4666/f2_4666.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from libcnmc.models.cnmcmodel import CNMCModel
 from libcnmc.models.fields import String, Integer, Decimal
 import string
+import re
 
 
 class F2Res4666(CNMCModel):
@@ -34,9 +35,7 @@ class F2Res4666(CNMCModel):
 
     @property
     def ref(self):
-        return ''.join(
-            c for c in self.store.identificador if c in string.digits
-        )
+        return re.sub('^{}'.format(self.trams_bt_prefix), '', self.store.identificador)
 
     def __cmp__(self, other):
         comp_fields = [


### PR DESCRIPTION
# Descripcion
- Mejora el importador del inventario 4666 para buscar según name y id_regulatorio - Cir8/2021

# Ficheros modificados
- f1_4666, f2_4666
