### PR TITLE
IMP Protege IDENTIFICADOR si se introduce manualmente un registro y no se rellena C3 - Cir8/2021

### DIFF
--- a/libcnmc/cir_8_2021/FC3.py
+++ b/libcnmc/cir_8_2021/FC3.py
@@ -51,7 +51,7 @@ class FC3(StopMultiprocessBased):
                     format_f(c3.get('inversion_n_2', 0.0), 2),
                     format_f(c3.get('gasto', 0.0), 2),
                     format_f(c3.get('ingreso', 0.0), 2),
-                    c3.get('identificador', ''),
+                    c3.get('identificador', '') or '',
                 ])
                 self.input_q.task_done()
             except Exception:


### PR DESCRIPTION
# Descripcion
- Protege IDENTIFICADOR si se introduce manualmente un registro y no se rellena - Cir8/2021

# Ficheros modificados
- C3
