### PR TITLE
IMP Inicializa a 0 valores para cumplir con el validador A3 - Cir8/2021

### DIFF
--- a/libcnmc/cir_8_2021/FA3.py
+++ b/libcnmc/cir_8_2021/FA3.py
@@ -93,17 +93,17 @@ class FA3(StopMultiprocessBased):
                     o_year_previsto = prevision['year_previsto']
 
                 # SUMINISTROS BT
-                o_suministros_bt = ''
+                o_suministros_bt = 0
                 if prevision['suministros_bt']:
                     o_suministros_bt = prevision['suministros_bt']
 
                 # SUMINISTROS MT
-                o_suministros_mt = ''
+                o_suministros_mt = 0
                 if prevision['suministros_mt']:
                     o_suministros_mt = prevision['suministros_mt']
 
                 # SUMINISTROS AT
-                o_suministros_at = ''
+                o_suministros_at = 0
                 if prevision['suministros_at']:
                     o_suministros_at = prevision['suministros_at']
 


### PR DESCRIPTION
# Descripcion
- Inicializa a 0 valores para cumplir con el validador A3

# Ficheros modificados
- A3
