### PR TITLE
Fixed cerberus requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ libcomxml
 chardet
 pyproj==2.2.2
 osconf
-cerberus>=1.0
+cerberus>1.0,<=1.3.4;python_version<="2.7.18"
+cerberus>1.0;python_version>"2.7.18"
 python-dateutil
 shapely


### PR DESCRIPTION
# Descripcion
- Fijar el rango de versiones de `cerberus` para PY2 ya que la 1.3.5 no tiene wheel

```
ERROR: Exception:
Traceback (most recent call last):                                                                                                                                                                                                           
  File "/home/ci_replicante/.pyenv/versions/2.7.18/envs/peru/lib/python2.7/site-packages/pip/_internal/cli/base_command.py", line 223, in _main                                                                                              
    status = self.run(options, args)                                                                                                                                                                                                         
  File "/home/ci_replicante/.pyenv/versions/2.7.18/envs/peru/lib/python2.7/site-packages/pip/_internal/cli/req_command.py", line 180, in wrapper                                                                                             
    return func(self, options, args)                                                                                                                                                                                                         
  File "/home/ci_replicante/.pyenv/versions/2.7.18/envs/peru/lib/python2.7/site-packages/pip/_internal/commands/install.py", line 321, in run                                                                                                
    reqs, check_supported_wheels=not options.target_dir                                                                                                                                                                                      
  File "/home/ci_replicante/.pyenv/versions/2.7.18/envs/peru/lib/python2.7/site-packages/pip/_internal/resolution/legacy/resolver.py", line 180, in resolve                                                                                  
    discovered_reqs.extend(self._resolve_one(requirement_set, req))                                                                                                                                                                          
  File "/home/ci_replicante/.pyenv/versions/2.7.18/envs/peru/lib/python2.7/site-packages/pip/_internal/resolution/legacy/resolver.py", line 420, in _resolve_one                                                                             
    assert req_to_install.user_supplied                                                                                                                                                                                                      
AssertionError       
```

```bash
Building wheels for collected packages: unknown, unknown
  Building wheel for unknown (PEP 517) ... done
  Created wheel for unknown: filename=UNKNOWN-0.0.0-py2-none-any.whl size=2494 sha256=3bc15677267372a42dc4d55563c716cfb59f7d50043c7ff6a7f6f2e14bde8296
  Stored in directory: /home/ci_replicante/.cache/pip/wheels/b6/17/b8/ec697086f62e926db3fb895c98ca494d74df45d839030b1026
  Building wheel for unknown (PEP 517) ... done
  Created wheel for unknown: filename=UNKNOWN-0.0.0-py2-none-any.whl size=2494 sha256=8579a695abdcf638063af2839d5eafd598979281bc888c1fe6455b99fb7253ca
  Stored in directory: /home/ci_replicante/.cache/pip/wheels/cb/eb/c1/47f27d66848de0cec1aa9a3ad5e4dd79b46e4f162942bc657e
Successfully built unknown unknown
Installing collected packages: unknown
Successfully installed unknown-0.0.0

```

# Ficheros modificados
- requirements.txt
