### PR TITLE
 Añadir el campo id_regulatori en B5 - Cir8/2021

### DIFF
--- a/libcnmc/cir_8_2021/FB5.py
+++ b/libcnmc/cir_8_2021/FB5.py
@@ -64,7 +64,7 @@ class FB5(StopMultiprocessBased):
     def consumer(self):
         o = self.connection
         fields_to_read = [
-            'ct', 'name', 'cini', 'potencia_nominal', 'id_estat', 'node_id', 'data_pm', 'data_baixa',
+            'ct', 'name', 'cini', 'potencia_nominal', 'id_estat', 'node_id', 'data_pm', 'data_baixa', 'id_regulatori',
             'tipus_instalacio_cnmc_id', 'node_baixa', 'model', self.compare_field
         ]
         fields_to_read_obra = [
@@ -179,7 +179,7 @@ class FB5(StopMultiprocessBased):
                         else data_ip
 
                 o_subestacio = trafo['ct'][1]
-                o_maquina = trafo['name']
+                o_maquina = trafo.get('id_regulatori', trafo['name'])
                 o_cini = trafo['cini']
                 o_pot_maquina = format_f(
                     float(trafo['potencia_nominal']) / 1000.0, decimals=3)

--- a/libcnmc/cir_8_2021/FB5.py
+++ b/libcnmc/cir_8_2021/FB5.py
@@ -179,7 +179,7 @@ class FB5(StopMultiprocessBased):
                         else data_ip
 
                 o_subestacio = trafo['ct'][1]
-                o_maquina = trafo.get('id_regulatori', trafo['name'])
+                o_maquina = trafo.get('id_regulatori', trafo['name']).strip() or trafo['name']
                 o_cini = trafo['cini']
                 o_pot_maquina = format_f(
                     float(trafo['potencia_nominal']) / 1000.0, decimals=3)


### PR DESCRIPTION
# Para el versionado automático seleccionar uno de los siguientes labels:
- **major**: Major auto version vX._._
- **minor**: Minor auto version v_.X._
- **patch**: Patch auto version v_._.X

De esta forma el proceso de versionado se hará de forma automática

# Descripcion
- Se utiliza `id_regulatori` siempre que exista en el fichero B5

# Ficheros modificados
- `FB5.py`
