### PR TITLE
IMP Calculo tension A1 por traza de acometidas

### DIFF
--- a/libcnmc/cir_8_2021/FA1.py
+++ b/libcnmc/cir_8_2021/FA1.py
@@ -566,7 +566,9 @@ class FA1(StopMultiprocessBased):
                     # pensat que la tensió s'intentés agafar de la pòlissa,
                     # després intentar per modcon, despreś de la traça de
                     # l'escomesa i, sino resulta cap, llavors es deixa buit.
+                    # Todo: Revisar si es pot eliminar
                     ###########################################################
+
                     # Es comenta per NOTA (1)
                     # if polissa['tensio']:
                     #     o_tensio = format_f(
@@ -651,7 +653,7 @@ class FA1(StopMultiprocessBased):
                         fields_to_read_modcon = [
                             'cnae',
                             'tarifa',
-                            'tensio',
+                            # 'tensio',
                             'potencia',
                             'polissa_id',
                             'data_final'
@@ -687,6 +689,7 @@ class FA1(StopMultiprocessBased):
                         if self.default_o_cod_tfa:
                             o_cod_tfa = self.default_o_cod_tfa
                 # Es tabula enrera fora del 'else' anterior per NOTA (1)
+                # Tensió d'alimentació en kV
                 if cups.get('id_escomesa', False):
                     search_params = [
                         ('escomesa', '=', cups['id_escomesa'][0])

--- a/libcnmc/cir_8_2021/FA1.py
+++ b/libcnmc/cir_8_2021/FA1.py
@@ -554,15 +554,23 @@ class FA1(StopMultiprocessBased):
 
                 if polissa_id:
                     fields_to_read = [
-                        'potencia', 'cnae', 'tarifa', 'butlletins', 'tensio'
+                        'potencia', 'cnae', 'tarifa', 'butlletins'#, 'tensio'
                     ]
                     polissa_id = polissa_id[0]
                     polissa = O.GiscedataPolissa.read(
                         polissa_id, fields_to_read, context_glob
                     )
-                    if polissa['tensio']:
-                        o_tensio = format_f(
-                            float(polissa['tensio']) / 1000.0, decimals=3)
+                    ###########################################################
+                    # NOTA (1):
+                    # De moment es deixa comentat. Inicalment estava
+                    # pensat que la tensió s'intentés agafar de la pòlissa,
+                    # després intentar per modcon, despreś de la traça de
+                    # l'escomesa i, sino resulta cap, llavors es deixa buit.
+                    ###########################################################
+                    # Es comenta per NOTA (1)
+                    # if polissa['tensio']:
+                    #     o_tensio = format_f(
+                    #         float(polissa['tensio']) / 1000.0, decimals=3)
                     o_potencia = polissa['potencia']
                     if polissa['cnae']:
                         cnae_id = polissa['cnae'][0]
@@ -665,34 +673,36 @@ class FA1(StopMultiprocessBased):
                                     cnae_id, ['name']
                                 )['name']
                                 self.cnaes[cnae_id] = o_cnae
-                        if modcon['tensio']:
-                            o_tensio = format_f(
-                                float(modcon['tensio']) / 1000.0, decimals=3)
+                        # Es comenta per NOTA (1)
+                        # if modcon['tensio']:
+                        #     o_tensio = format_f(
+                        #         float(modcon['tensio']) / 1000.0, decimals=3)
                         if modcon['potencia']:
                             o_potencia = modcon['potencia']
                     else:
                         # No existeix modificació contractual per el CUPS
                         o_potencia = cups['potencia_conveni']
-                        if cups.get('id_escomesa', False):
-                            search_params = [
-                                ('escomesa', '=', cups['id_escomesa'][0])
-                            ]
-                            id_esc_gis = O.GiscegisEscomesesTraceability.search(
-                                search_params
-                            )
-
-                            if id_esc_gis:
-                                tensio_gis = O.GiscegisEscomesesTraceability.read(
-                                    id_esc_gis, ['tensio']
-                                )[0]['tensio']
-                                o_tensio = format_f(
-                                    float(tensio_gis) / 1000.0, decimals=3)
-                        else:
-                            o_tensio = ''
                         if self.default_o_cnae:
                             o_cnae = self.default_o_cnae
                         if self.default_o_cod_tfa:
                             o_cod_tfa = self.default_o_cod_tfa
+                # Es tabula enrera fora del 'else' anterior per NOTA (1)
+                if cups.get('id_escomesa', False):
+                    search_params = [
+                        ('escomesa', '=', cups['id_escomesa'][0])
+                    ]
+                    id_esc_gis = O.GiscegisEscomesesTraceability.search(
+                        search_params
+                    )
+
+                    if id_esc_gis:
+                        tensio_gis = O.GiscegisEscomesesTraceability.read(
+                            id_esc_gis, ['tensio']
+                        )[0]['tensio']
+                        o_tensio = format_f(
+                            float(tensio_gis) / 1000.0, decimals=3)
+                else:
+                    o_tensio = ''
 
                 # potencia adscrita
                 o_pot_ads = 0


### PR DESCRIPTION
# Descripcion
- _Hasta ahora se utilizaba el siguiente orden para el cálculo de la tensión para el Formulario A1:_
   - _Se usa el de la póliza_
   - _Se usa el de modcon_
   - _Se usa el que tiene la acometida por trazabilidad_

- Ahora sólo se mirará por lo que tenga la acometida por trazabilidad. En caso de no tener lo deja vacío.

- Se decide dejar el código anterior comentado de momento.

# Ficheros modificados
- `FA1.py`
