### PR TITLE
Corrección al acceder a la propiedad compare_field

### DIFF
--- a/libcnmc/cir_8_2021/FB1.py
+++ b/libcnmc/cir_8_2021/FB1.py
@@ -579,7 +579,7 @@ class FB1(StopMultiprocessBased):
                     fields_to_read = ['name', 'cini', 'coeficient', 'municipi', 'voltatge', 'tensio_const',
                                       'coeficient', 'longitud_cad', 'punt_frontera', 'model', 'operacion',
                                       'propietari', 'edge_id', 'cable', 'tipus_instalacio_cnmc_id',
-                                      'data_pm', 'data_baixa', 'id_regulatori', self.compare_field,
+                                      'data_pm', 'data_baixa', 'id_regulatori',
                                       'perc_financament',
                                       ]
 


### PR DESCRIPTION
# Descripcion
- Corrección al acceder a la propiedad `self.compare_field` eliminada en la v24

# Ficheros modificados
- B1
