### PR TITLE
Corrección en la comparación del fichero B1 en tramos de baja

### DIFF
--- a/libcnmc/cir_8_2021/FB1.py
+++ b/libcnmc/cir_8_2021/FB1.py
@@ -867,7 +867,7 @@ class FB1(StopMultiprocessBased):
                                 'cini', 'codigo_ccuu', 'longitud',
                                 'tension_explotacion', 'fecha_aps'
                             ])
-                            entregada = F1Res4666(
+                            entregada = F2Res4666(
                                 cini=hist['cini'],
                                 longitud=hist['longitud'],
                                 codigo_ccuu=hist['codigo_ccuu'],


### PR DESCRIPTION
# Descripcion
- Se utilizaba el F1Res4666 por error y se ha pasado a utilizar el F2Res4666

# Ficheros modificados
- B1
