### PR TITLE
B6: Sólo las celdas que esten en soportes AT

### DIFF
--- a/libcnmc/cir_8_2021/FB6.py
+++ b/libcnmc/cir_8_2021/FB6.py
@@ -57,7 +57,7 @@ class FB6(StopMultiprocessBased):
                               ('data_baixa', '=', False)]
 
         search_params += [
-            ("tipus_element.codi_cnmc", "!=", "T"),
+            ("installacio", '=like', 'giscedata.at.suport,%'),
             ('inventari', '=', 'fiabilitat'),
         ]
 


### PR DESCRIPTION
# Descripcion
- Se cambia el filtro para que sólo se tengan en cuenta las celdas que sean del tipo 'fiabilidad' y que estén en soportes AT

# Ficheros modificados
- B6
