### PR TITLE
B2.2: Eliminación restricción no sea FUS_AT

### DIFF
--- a/libcnmc/cir_8_2021/FB2_2.py
+++ b/libcnmc/cir_8_2021/FB2_2.py
@@ -36,10 +36,7 @@ class FB2_2(StopMultiprocessBased):
         :return: None
         """
         cella_obj = self.connection.GiscedataCellesCella
-        search_params = [
-            ("installacio", "like", "%giscedata.cts%"),
-            ("tipus_element.codi", "!=", "FUS_AT")
-        ]
+        search_params = [('cini', '=like', 'I28%')]
 
         data_pm = '{}-01-01'.format(self.year + 1)
         data_baixa = '{}-12-31'.format(self.year)
@@ -56,15 +53,7 @@ class FB2_2(StopMultiprocessBased):
                           ('active', '=', True)]
 
         cell_ids = cella_obj.search(search_params, 0, 0, False, {'active_test': False})
-        ids_cini_data = cella_obj.read(cell_ids, ['cini'])
-        ids_i28 = []
-        for cell_data in ids_cini_data:
-            cini = cell_data['cini']
-            if cini:
-                if cini[:3] == 'I28':
-                    ids_i28.append(cell_data['id'])
-
-        return ids_i28
+        return cell_ids
 
     def get_codi_ct(self, ct_id):
         o = self.connection


### PR DESCRIPTION
# Descripcion
- Eliminación restricción que no sea FUS_AT y solo se mira el CINI **I28**

# Ficheros modificados
- B2.2
