### PR TITLE
A1: Eliminar vaciar CAU si COD_AUTO '002', '003', '005', '007'

### DIFF
--- a/libcnmc/cir_8_2021/FA1.py
+++ b/libcnmc/cir_8_2021/FA1.py
@@ -471,9 +471,6 @@ class FA1(StopMultiprocessBased):
                     if autoconsum_data.get('cau', False):
                         o_cau = autoconsum_data['cau']
 
-                    if o_cod_auto in ['002', '003', '005', '007']:
-                        o_cau = ''
-
                     # COD_GENERACION_AUTO
                     if autoconsum_data.get('generador_id', False):
                         generador_id = autoconsum_data['generador_id'][0]


### PR DESCRIPTION
# Descripcion
- A1: Eliminar vaciar CAU si COD_AUTO '002', '003', '005', '007'
- Reverts: https://github.com/gisce/libCNMC/pull/550

# Ficheros modificados
- A1
