### PR TITLE
FD2: Se exportaban los datos sin distinguir por año

### DIFF
--- a/libcnmc/cir_8_2021/FD2.py
+++ b/libcnmc/cir_8_2021/FD2.py
@@ -34,7 +34,6 @@ class FD2(StopMultiprocessBased):
         """
 
         search_params = [
-            '|',
             ('active', '=', True),
             ('year', '=', self.year),
             ('cod_gestion.name', '!=', 'Z8_01_dl15')


### PR DESCRIPTION
# Descripcion
- Evista la exportación de datos de mas de un año. 

# Ficheros modificados
- FD2
