### PR TITLE
FIX calculo campo ajena en formulario B4 Circular 8_2021

### DIFF
--- a/libcnmc/cir_8_2021/FB4.py
+++ b/libcnmc/cir_8_2021/FB4.py
@@ -268,10 +268,15 @@ class FB4(StopMultiprocessBased):
                     ti = ''
 
                 #AJENA
-                if pos['propietari']:
-                    ajena = 0
-                else:
-                    ajena = 1
+                ajena = 1
+                if pos.get('propietari', False):
+                    # Agafar la propietat de les Posicions a on la Subestació
+                    # també és propietat
+                    if pos.get('subestacio_id', False):
+                        sub_id = pos['subestacio_id'][0]
+                        se_data = self.get_cts_data(sub_id)
+                        if se_data.get('propietari', False):
+                            ajena = 0
 
                 #NODE
                 if pos['node_id']:


### PR DESCRIPTION
# Descripcion

- Arreglar el cálculo del campo Ajena en el formulario B4 de la Circular 8/2021. 
- Tal como se especifica en el texto refundido de la Circular 8/2021, el valor del campo AJENA será 1 si la posición se encuentra ubicada en una Subestación ajena a la distribuidora. 
![image](https://github.com/gisce/libCNMC/assets/29188524/b336d64e-1a81-4feb-a08f-60d3c7c24c42)
Es decir, en aquellos casos en los que, en la Subestación, el campo `Propietario` se encuentra desmarcado.
![image](https://github.com/gisce/libCNMC/assets/29188524/cac5d04a-1573-491d-bc82-bc6cce765802)

[Arreglo del cálculo del campo AJENA del formulário B4](https://rfc.gisce.net/t/arreglo-del-calculo-del-campo-ajena-del-formulario-b4/2010)

# Ficheros modificados
- B4 -> `libcnmc/cir_8_2021/FB4.py`
