### PR TITLE
FIX nombre subestación en Identificador emplazamiento

### DIFF
--- a/libcnmc/cir_8_2021/FB4.py
+++ b/libcnmc/cir_8_2021/FB4.py
@@ -104,6 +104,14 @@ class FB4(StopMultiprocessBased):
             cts_data = o.GiscedataCts.read(cts_id['ct_id'][0], ['propietari', 'node_id', 'punt_frontera', 'model'])
         return cts_data
 
+    def get_tensio(self, sub):
+        o = self.connection
+        res = ''
+        if sub['tensio']:
+            tensio_obj = o.GiscedataTensionsTensio.read(sub['tensio'][0])
+            res = tensio_obj['tensio']
+        return res
+
     def consumer(self):
         """
         Generates the line of the file

--- a/libcnmc/cir_8_2021/FB4.py
+++ b/libcnmc/cir_8_2021/FB4.py
@@ -104,13 +104,23 @@ class FB4(StopMultiprocessBased):
             cts_data = o.GiscedataCts.read(cts_id['ct_id'][0], ['propietari', 'node_id', 'punt_frontera', 'model'])
         return cts_data
 
-    def get_tensio(self, sub):
+    def get_subestacio(self, sub_id):
+        """
+        Returns the SE data
+        :param sub_id: ID of SE
+        :type sub_id: int
+        :return: Node, Name, CINI and CT-ID of the SE
+        :rtype: dict[str,str]
+        """
+
         o = self.connection
-        res = ''
-        if sub['tensio']:
-            tensio_obj = o.GiscedataTensionsTensio.read(sub['tensio'][0])
-            res = tensio_obj['tensio']
-        return res
+        sub = o.GiscedataCtsSubestacions.read(
+            sub_id, ['name']
+        )
+        ret = {
+            "name": sub['name'],
+        }
+        return ret
 
     def consumer(self):
         """
@@ -259,12 +269,12 @@ class FB4(StopMultiprocessBased):
                     else data_ip
 
                 #IDENTIFICADOR_EMPLAZAMIENTO
-                if pos['parc_id']:
+                identificador_emplazamiento = ''
+                if pos.get('parc_id', False): # nom Parc
                     identificador_emplazamiento = pos['parc_id'][1]
-                else:
-                    o_parc = pos['subestacio_id'][1] + "-"\
-                        + str(self.get_tensio(pos))
-                    identificador_emplazamiento = "SUBESTACIO_NAME"
+                elif pos.get('subestacio_id', False): # nom Subestació
+                    sub_data = self.get_subestacio(pos['subestacio_id'][0])
+                    identificador_emplazamiento =  sub_data.get('name', '')
 
                 #CODIGO CCUU
                 if pos['tipus_instalacio_cnmc_id']:


### PR DESCRIPTION
# Descripcion

- El formulario B4, en cierto momento, debe calcular el valor del campo IDENTIFICADOR_EMPLAZAMIENTO. Éste viene dado por, o bién el nombre del Parque o bién de la Subestación, al que la posición se encuentra asociada.

Segun el BOE-A-2021-21003 debe coincidir al identificador de la S.E. para el formulario B3 o de parque segun el B3.1. 
![image](https://github.com/gisce/libCNMC/assets/29188524/b68e20fd-1583-4d5b-9511-c085af14832d)

En el caso de que sea de la subestación (formulario B3) se usaba una cadena fija y debe ser el valor del campo `name` de la SE. 

# Ficheros modificados
- B4 -> `libcnmc/cir_8_2021/FB4.py`
