### PR TITLE
FIX comparar fecha de obra con fecha aps inexistente

### DIFF
--- a/libcnmc/cir_8_2021/FB1.py
+++ b/libcnmc/cir_8_2021/FB1.py
@@ -320,7 +320,9 @@ class FB1(StopMultiprocessBased):
                     # CAMPS OBRA
                     if tram_obra != '':
                         obra_year = data_finalitzacio.split('-')[0]
-                        data_pm_year = fecha_aps.split('/')[2]
+                        data_pm_year = (
+                                fecha_aps and fecha_aps.split('/')[2] or ''
+                        )
                         if tram_obra['tipo_inversion'] != '0' and obra_year != data_pm_year:
                             data_ip = convert_spanish_date(data_finalitzacio)
                         else:


### PR DESCRIPTION
# Descripcion

- Cuando se tiene un tramo sin fecha APS pero éste forma parte de un Trabajo de Inversión saltaba error `IndexError: list index out of range` en el momento de calcular el valor de la fecha de la inversión parcial.


# Ficheros modificados

- B1
