### PR TITLE
Exportar unicamente datos de el año actual en Z8_01

### DIFF
--- a/libcnmc/cir_8_2021/FD2.py
+++ b/libcnmc/cir_8_2021/FD2.py
@@ -72,7 +72,10 @@ class FD2(StopMultiprocessBased):
                     ]
                     self.output_q.put(output)
                 else:
-                    d2_z8_15 = d2_obj.search([('active', '=', True), ('cod_gestion.name', '=', 'Z8_01_dl15')])[0]
+                    d2_z8_15 = d2_obj.search([('active', '=', True),
+                                              ('cod_gestion.name', '=', 'Z8_01_dl15'),
+                                              ('year', '=', self.year)])[0]
+
                     d2_z8_15 = d2_obj.read(d2_z8_15, [])
                     solicitudes = cod_gest_data['solicitudes'] + d2_z8_15['solicitudes']
                     en_plazo = cod_gest_data['en_plazo'] + d2_z8_15['en_plazo']


### PR DESCRIPTION

De esta forma el proceso de versionado se hará de forma automática

# Descripcion
- Se ha corregido la búsqueda de valores para la Z8_01 para que use unicamente los del año a exportar

# Ficheros modificados
- FD2
