### PR TITLE
Update requirements for py3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
-progressbar<=2.3
+progressbar<=2.3;python_version<="2.7.18"
+progressbar>=2.5;python_version>"2.7.18"
 click<7.0
 libcomxml
 chardet
-pyproj==2.2.2
+pyproj==2.2.2;python_version<="2.7.18"
+pyproj;python_version>"2.7.18"
 osconf
 cerberus>1.0,<=1.3.4;python_version<="2.7.18"
 cerberus>1.0;python_version>"2.7.18"


### PR DESCRIPTION
Actualiza los requerimientos para python 3, de momento la ibreria no es compatible pero ahora se puede instalar
