### PR TITLE
IMP excluir de los ids a consumir las bajas de modelo M

### DIFF
--- a/libcnmc/cir_8_2021/FB1.py
+++ b/libcnmc/cir_8_2021/FB1.py
@@ -88,6 +88,10 @@ class FB1(StopMultiprocessBased):
                           '&', ('active', '=', False),
                                ('data_baixa', '!=', False),
                           ('active', '=', True)]
+        # Excloure els registres que es troben de baixa i el model es 'M'
+        search_params += [
+            '|', ('model', '!=', 'M'), ('data_baixa', '=', False)
+        ]
 
         obj_lat = self.connection.GiscedataAtTram
         ids = obj_lat.search(
@@ -114,6 +118,10 @@ class FB1(StopMultiprocessBased):
                           '&', ('active', '=', False),
                                ('data_baixa', '!=', False),
                           ('active', '=', True)]
+        # Excloure els registres que es troben de baixa i el model es 'M'
+        search_params += [
+            '|', ('model', '!=', 'M'), ('data_baixa', '=', False)
+        ]
 
         obj_lbt = self.connection.GiscedataBtElement
         ids = obj_lbt.search(
@@ -135,7 +143,7 @@ class FB1(StopMultiprocessBased):
 
         fields_to_read = [
             'baixa', 'data_pm', 'data_industria', 'coeficient', 'cini', 'propietari', 'tensio_max_disseny_id', 'name',
-            'origen', 'final', 'perc_financament', 'longitud_cad', 'cable', 'linia', 'model', 'model', 'punt_frontera',
+            'origen', 'final', 'perc_financament', 'longitud_cad', 'cable', 'linia', 'model', 'punt_frontera',
             'tipus_instalacio_cnmc_id', 'data_baixa', 'baixa', 'longitud_cad', 'data_pm', 'circuits',
             'id_regulatori', 'municipi',
         ]

--- a/libcnmc/cir_8_2021/FB2.py
+++ b/libcnmc/cir_8_2021/FB2.py
@@ -66,6 +66,10 @@ class FB2(StopMultiprocessBased):
                           '&', ('active', '=', False),
                                ('data_baixa', '!=', False),
                           ('active', '=', True)]
+        # Excloure els registres que es troben de baixa i el model es 'M'
+        search_params += [
+            '|', ('model', '!=', 'M'), ('data_baixa', '=', False)
+        ]
 
         forced_ids = get_forced_elements(self.connection, "giscedata.cts")
 

--- a/libcnmc/cir_8_2021/FB4.py
+++ b/libcnmc/cir_8_2021/FB4.py
@@ -86,6 +86,10 @@ class FB4(StopMultiprocessBased):
                           '&', ('active', '=', False),
                           ('data_baixa', '!=', False),
                           ('active', '=', True)]
+        # Excloure els registres que es troben de baixa i el model es 'M'
+        search_params += [
+            '|', ('model', '!=', 'M'), ('data_baixa', '=', False)
+        ]
 
         forced_ids = get_forced_elements(self.connection, "giscedata.cts.subestacions.posicio")
 

--- a/libcnmc/cir_8_2021/FB6.py
+++ b/libcnmc/cir_8_2021/FB6.py
@@ -60,7 +60,10 @@ class FB6(StopMultiprocessBased):
             ('cini', '=like', 'I26%'),
             ('inventari', '=', 'fiabilitat'),
         ]
-
+        # Excloure els registres que es troben de baixa i el model es 'M'
+        search_params += [
+            '|', ('model', '!=', 'M'), ('data_baixa', '=', False)
+        ]
         return self.connection.GiscedataCellesCella.search(search_params, 0, 0, False, {'active_test': False})
 
     def get_node_vertex(self, element_name):


### PR DESCRIPTION
# Descripcion
Si una instalación se declara como modelo M y decide no volver a declararse en ejercicios posteriores, no es necesario darla de baja de manera formal. Bastará con no declararla en el ejercicio que corresponda. Así, para conseguir esta condición se desarrolla la siguiente mejora:

- En los formularios sobre instalaciones (formularios B) que contienen el campo `MODELO` y su valor es `'M'` excluir aquellos dados de baja en el año a retribuir.

# Ficheros modificados
- B1, B2, B4 y B6
