### PR TITLE
FIX llamada a funcion para inactivos usando context A2

### DIFF
--- a/libcnmc/cir_8_2021/FA2.py
+++ b/libcnmc/cir_8_2021/FA2.py
@@ -51,10 +51,10 @@ class FA2(StopMultiprocessBased):
             ('data_alta', '<', data_pm), ('collectiu', '=', True)
         ]
         autoconsum_ids = O.GiscedataAutoconsum.search(
-            search_params_ac, context={'active_test': False})
+            search_params_ac, 0, 0, False, {"active_test": False})
         search_params_gen = [('autoconsum_id', 'in', autoconsum_ids)]
         generador_ids = O.GiscedataAutoconsumGenerador.search(
-            search_params_gen, context={'active_test': False})
+            search_params_gen, 0, 0, False, {"active_test": False})
 
         for elem in range(0, len(autoconsum_ids)):
              generador_ids[elem] = 'gac.{}'.format(generador_ids[elem])


### PR DESCRIPTION
# Descripcion
- FIX error en llamada a función en la que no se pasan correctamente los parámetros para poder especificar el `context` y así incluir los registros no activos

# Ficheros modificados
- A2
