### PR TITLE
FIX valor 2 en A2 para autoconsumos colectivos

### DIFF
--- a/libcnmc/cir_8_2021/FA2.py
+++ b/libcnmc/cir_8_2021/FA2.py
@@ -364,7 +364,7 @@ class FA2(StopMultiprocessBased):
                         o_potencia_instalada = gen['pot_instalada_gen']
 
                     # Autoconsum
-                    o_autoconsum = 1 # Es força a valor fixe 1
+                    o_autoconsum = 2 # Es força a valor fixe 2
 
                     # CAU
                     o_cau = cau


### PR DESCRIPTION
# Descripcion
- Para Autoconsumos colectivos se fija el valor del campo `AUTOCONSUMO` a 2

# Ficheros modificados
- A2
