### PR TITLE
A2: FIX los valores de las energias en decimales con coma

### DIFF
--- a/libcnmc/cir_8_2021/FA2.py
+++ b/libcnmc/cir_8_2021/FA2.py
@@ -402,10 +402,10 @@ class FA2(StopMultiprocessBased):
                         o_connexion,                                    # Connexió
                         ('{}'.format(o_tension)).replace('.', ','),     # Tensió
                         o_potencia_instalada,                           # Potència instalada
-                        o_energia_activa_producida,                     # Energia activa produida
-                        o_energia_activa_consumida,                     # Energia activa consumida
-                        o_energia_reactiva_producida,                   # Energia reactiva produida
-                        o_energia_reactiva_consumida,                   # Energia reactiva consumida
+                        format_f(o_energia_activa_producida, decimals=3),   # Energia activa produida
+                        format_f(o_energia_activa_consumida, decimals=3),   # Energia activa consumida
+                        format_f(o_energia_reactiva_producida, decimals=3), # Energia reactiva produida
+                        format_f(o_energia_reactiva_consumida, decimals=3), # Energia reactiva consumida
                         o_autoconsum,                                   # Autoconsum
                         o_cau,                                          # CAU
                         o_cups_ssaa                                     # Serveis auxiliars


### PR DESCRIPTION
# Descripcion
- Hacer que los valores resultantes que se generan para las energías venga con un formato de coma ('`,`').  

# Ficheros modificados
- A2
