### PR TITLE
FIX fijar valor autoconsumo a 1 para generadores AC A2

### DIFF
--- a/libcnmc/cir_8_2021/FA2.py
+++ b/libcnmc/cir_8_2021/FA2.py
@@ -364,7 +364,7 @@ class FA2(StopMultiprocessBased):
                         o_potencia_instalada = gen['pot_instalada_gen']
 
                     # Autoconsum
-                    o_autoconsum = 2 # Es força a valor fixe 2
+                    o_autoconsum = 1 # Es força a valor fixe 1 (Autoconsum)
 
                     # CAU
                     o_cau = cau


### PR DESCRIPTION
# Descripcion
- No existe valor `2: Autoconsumo colectivo` en el campo de `AUTOCONSUMO` en el A2. Se confundió por el de la explicación aclaratoria del A1 en el FAQ de 2024 de la Circular 8/2021.
- Para los registros correspondientes a Generadores de Autoconsumo procedentes de autoconsumo colectivo se fija su valor a `1: Con autoconsumo`.

Error procedente de https://github.com/gisce/libCNMC/pull/666

# Ficheros modificados
- A2
