### PR TITLE
Tener en cuenta CUPS desactivados A1

### DIFF
--- a/libcnmc/cir_8_2021/FA1.py
+++ b/libcnmc/cir_8_2021/FA1.py
@@ -197,10 +197,15 @@ class FA1(StopMultiprocessBased):
         :return: List of CUPS
         :rtype: list[int]
         """
-        data_ini = '%s-01-01' % (self.year + 1)
-        search_params = [('active', '=', True),
+        data_ini = '%s-01-01' % self.year
+        data_fi = '%s-12-31' % self.year
+        search_params = ['|',
+                         ('active', '=', True),
+                         '&',
+                         ('data_baixa', '>=', data_ini),
+                         ('data_baixa', '<=', data_fi),
                          '|',
-                         ('create_date', '<', data_ini),
+                         ('create_date', '<=', data_fi),
                          ('create_date', '=', False)]
 
         ret_cups_ids = self.connection.GiscedataCupsPs.search(


### PR DESCRIPTION
# Descripción
- En la generación del fichero A1, se estaban teniendo en cuenta solamente los CUPS activos. Pero pueden existir CUPS desactivados para el año a retribuir.
- Se modifican los parámetros de búsqueda para tener en cuenta aquellos desactivados pero con fecha de baja el año a retribuir.

# Ficheros modificados
- A1

TASK-71229
