### PR TITLE
Revisar si el Autoconsumo esta activo para retribucion

### DIFF
--- a/libcnmc/cir_8_2021/FA1.py
+++ b/libcnmc/cir_8_2021/FA1.py
@@ -464,12 +464,12 @@ class FA1(StopMultiprocessBased):
 
     def get_modcon_tipus_subseccio_by_year(self, cups, year):
         """
-        Returns the 'tipus_subseccio' value from the last 'Modcontractual' of
-        the year passed as parameter
+        Retorna el valor del 'tipus_subseccio' de la ultima 'Modcontractual' de
+        l'any passat per parametre
 
-        :param cups: CUPS name
+        :param cups: Nom CUPS
         :param cups: str
-        :return: 'tipus_subseccio' code
+        :return: Codi 'tipus_subseccio'
         :rtype: str
         """
         O = self.connection
@@ -477,7 +477,7 @@ class FA1(StopMultiprocessBased):
         year_last_day = '%s-12-31' % year
         modcon_obj = O.GiscedataPolissaModcontractual
         modcon_ids = modcon_obj.search(
-            [('cups', 'ilike', cups)], context={'active_test':False})
+            [('cups', 'ilike', cups)], 0, 0, False, {'active_test': False})
         modcon_data = sorted(
             modcon_obj.read(
                 modcon_ids, ['data_final', 'data_inici', 'tipus_subseccio']),
@@ -491,6 +491,8 @@ class FA1(StopMultiprocessBased):
                 if (modcon['data_final'] >= year_first_day
                         and modcon['data_inici'] <= year_last_day):
                     tipus_subseccio = modcon.get('tipus_subseccio')
+                    break # nomes volem la ultima activa en cas d'existir
+                          # varies aquell mateix any
         return tipus_subseccio
 
     def consumer(self):

--- a/libcnmc/cir_8_2021/FA1.py
+++ b/libcnmc/cir_8_2021/FA1.py
@@ -484,7 +484,7 @@ class FA1(StopMultiprocessBased):
         date_data = cups_obj.get_modcontractual_intervals(
             cups_id, day_before, year_last_day)
         interval = date_data.get(day_before) or date_data.get(year_last_day)
-        if interval.get('id'):
+        if interval and interval.get('id'):
             pol_id = modcon_obj.read(
                 interval['id'], ['polissa_id'])['polissa_id'][0]
             autoconsum_data = pol_obj.read(

--- a/libcnmc/cir_8_2021/FA1.py
+++ b/libcnmc/cir_8_2021/FA1.py
@@ -479,14 +479,16 @@ class FA1(StopMultiprocessBased):
 
         autoconsum_code = ''
         year_last_day = '%s-12-31' % year
+        day_before = '%s-12-30' % year
 
-        interval = cups_obj.get_modcontractual_intervals(
-            cups_id, '%s-12-30' % year, year_last_day)
+        date_data = cups_obj.get_modcontractual_intervals(
+            cups_id, day_before, year_last_day)
+        interval = date_data.get(day_before) or date_data.get(year_last_day)
         if interval.get('id'):
             pol_id = modcon_obj.read(
                 interval['id'], ['polissa_id'])['polissa_id'][0]
             autoconsum_data = pol_obj.read(
-                pol_id, ['autoconsumo'], {'date': '2020-12-31'})
+                pol_id, ['autoconsumo'], {'date': year_last_day})
             if autoconsum_data.get('autoconsumo'):
                 autoconsum_code = autoconsum_data['autoconsumo']
 
@@ -569,7 +571,7 @@ class FA1(StopMultiprocessBased):
                 autoconsum_id_data = None
                 autoconsum_code = (
                     self.get_autoconsum_code_by_year(item, self.year))
-                if autoconsum_code != '00':
+                if autoconsum_code and autoconsum_code != '00':
                     autoconsum_id_data = (
                         cups_obj.get_autoconsum_on_date(item, ultim_dia_any))
 

--- a/libcnmc/cir_8_2021/FA1.py
+++ b/libcnmc/cir_8_2021/FA1.py
@@ -567,7 +567,8 @@ class FA1(StopMultiprocessBased):
                 o_conexion_autoconsumo = ''
 
                 cups_obj = O.GiscedataCupsPs
-                # check if AC is active in last modcontractual of self.year
+                # Revisar si l'autoconsum esta actiu a la ultima modcontractual
+                # de self.year
                 autoconsum_id_data = None
                 tipus_subseccio = (
                     self.get_modcon_tipus_subseccio_by_year(o_name, self.year))


### PR DESCRIPTION
# Descripción
- Revisar si el autoconsumo (AC) se encontraba activo en el año a retribuir. Hasta ahora se incluía todo aquel que fuera asociado a un CUPS, tuviera o no activa el AC en la póliza. Esto implicaba, por ejemplo, que se añadiera los datos de ACs en borrador.

# Ficheros modificados
- A1
