### PR TITLE
Autoconsumo colectivo debe marcarse con valor 2

### DIFF
--- a/libcnmc/cir_8_2021/FA2.py
+++ b/libcnmc/cir_8_2021/FA2.py
@@ -364,7 +364,7 @@ class FA2(StopMultiprocessBased):
                         o_potencia_instalada = gen['pot_instalada_gen']
 
                     # Autoconsum
-                    o_autoconsum = 1 # Es força a valor fixe 1 (Autoconsum)
+                    o_autoconsum = 2 # Es força a 2: Autoconsum Col·lectiu
 
                     # CAU
                     o_cau = cau


### PR DESCRIPTION
# Descripcion
- Segun el validador de la Circular, para el campo `AUTOCONSUMO` son válidos los suiguientes valores: 
   - 0: Sin autoconsumo
   - 2: autoconsumo colectivo

# Ficheros modificados
- A2
