### PR TITLE
Cálculo del ESTADO para elementos con MODELO=E (ficheros B)

### DIFF
--- a/libcnmc/cir_8_2021/FB1.py
+++ b/libcnmc/cir_8_2021/FB1.py
@@ -521,6 +521,8 @@ class FB1(StopMultiprocessBased):
                                 estado = 1
                         else:
                             estado = '1' if modelo == 'E' else '2'
+                            if fecha_aps and int(fecha_aps.split('/')[2]) != int(self.year):
+                                estado = '1'
 
                     if fecha_baja:
                         motivacion = ''
@@ -534,17 +536,6 @@ class FB1(StopMultiprocessBased):
 
                     if modelo == 'E':
                         tipo_inversion = '0'
-
-                    # ESTADO no pot ser 2 si FECHA_APS < 2022
-                    if not modelo == 'M':
-                        if fecha_aps:
-                            fecha_aps_year = int(fecha_aps.split('/')[2])
-                            if estado == '2' and fecha_aps_year != int(self.year):
-                                estado = '1'
-                            elif fecha_aps_year == int(self.year) and modelo != 'E':
-                                estado = '2'
-                        else:
-                            estado = '1'
 
                     # Buidem FECHA_IP si hi ha FECHA_BAJA
                     if fecha_baja:
@@ -917,6 +908,8 @@ class FB1(StopMultiprocessBased):
                                 estado = '1'
                         else:
                             estado = '1' if modelo == 'E' else '2'
+                            if fecha_aps and int(fecha_aps.split('/')[2]) != int(self.year):
+                                estado = '1'
 
                     if fecha_baja:
                         motivacion = ''
@@ -930,17 +923,6 @@ class FB1(StopMultiprocessBased):
 
                     if modelo == 'E':
                         tipo_inversion = '0'
-
-                    # ESTADO no pot ser 2 si FECHA_APS < 2022
-                    if not modelo == 'M':
-                        if fecha_aps:
-                            fecha_aps_year = int(fecha_aps.split('/')[2])
-                            if estado == '2' and fecha_aps_year != int(self.year):
-                                estado = '1'
-                            elif fecha_aps_year == int(self.year) and modelo != 'E':
-                                estado = '2'
-                        else:
-                            estado = '1'
 
                     # Buidem FECHA_IP si hi ha FECHA_BAJA
                     if fecha_baja:

--- a/libcnmc/cir_8_2021/FB1.py
+++ b/libcnmc/cir_8_2021/FB1.py
@@ -520,7 +520,7 @@ class FB1(StopMultiprocessBased):
                                 self.output_m.put("{} {}".format(tram["name"], adapt_diff(actual.diff(entregada))))
                                 estado = 1
                         else:
-                            estado = '2'
+                            estado = '1' if modelo == 'E' else '2'
 
                     if fecha_baja:
                         motivacion = ''
@@ -534,7 +534,6 @@ class FB1(StopMultiprocessBased):
 
                     if modelo == 'E':
                         tipo_inversion = '0'
-                        estado = '1'
 
                     # ESTADO no pot ser 2 si FECHA_APS < 2022
                     if not modelo == 'M':
@@ -542,7 +541,7 @@ class FB1(StopMultiprocessBased):
                             fecha_aps_year = int(fecha_aps.split('/')[2])
                             if estado == '2' and fecha_aps_year != int(self.year):
                                 estado = '1'
-                            elif fecha_aps_year == int(self.year):
+                            elif fecha_aps_year == int(self.year) and modelo != 'E':
                                 estado = '2'
                         else:
                             estado = '1'
@@ -917,7 +916,7 @@ class FB1(StopMultiprocessBased):
                                 self.output_m.put("{} {}".format(linia["name"], adapt_diff(actual.diff(entregada))))
                                 estado = '1'
                         else:
-                            estado = '2'
+                            estado = '1' if modelo == 'E' else '2'
 
                     if fecha_baja:
                         motivacion = ''
@@ -931,7 +930,6 @@ class FB1(StopMultiprocessBased):
 
                     if modelo == 'E':
                         tipo_inversion = '0'
-                        estado = '1'
 
                     # ESTADO no pot ser 2 si FECHA_APS < 2022
                     if not modelo == 'M':
@@ -939,7 +937,7 @@ class FB1(StopMultiprocessBased):
                             fecha_aps_year = int(fecha_aps.split('/')[2])
                             if estado == '2' and fecha_aps_year != int(self.year):
                                 estado = '1'
-                            elif fecha_aps_year == int(self.year):
+                            elif fecha_aps_year == int(self.year) and modelo != 'E':
                                 estado = '2'
                         else:
                             estado = '1'

--- a/libcnmc/cir_8_2021/FB2.py
+++ b/libcnmc/cir_8_2021/FB2.py
@@ -385,6 +385,8 @@ class FB2(StopMultiprocessBased):
                         estado = '1'
                 else:
                     estado = '1' if modelo == 'E' else '2'
+                    if data_pm and int(data_pm.split('/')[2]) != int(self.year):
+                        estado = '1'
 
                 # Fecha APS / Estado
                 if modelo == 'M':
@@ -410,17 +412,6 @@ class FB2(StopMultiprocessBased):
                     financiado = format_f(
                         100 - ct['perc_financament'], decimals=2
                     )
-
-                # ESTADO no pot ser 2 si FECHA_APS < 2022
-                if not modelo == 'M':
-                    if data_pm:
-                        fecha_aps_year = int(data_pm.split('/')[2])
-                        if estado == '2' and fecha_aps_year != int(self.year):
-                            estado = '1'
-                        elif fecha_aps_year == int(self.year) and modelo != 'E':
-                            estado = '2'
-                    else:
-                        estado = '1'
 
                 # Buidem FECHA_IP si hi ha FECHA_BAJA
                 if fecha_baja:

--- a/libcnmc/cir_8_2021/FB2.py
+++ b/libcnmc/cir_8_2021/FB2.py
@@ -384,7 +384,7 @@ class FB2(StopMultiprocessBased):
                         self.output_m.put("{} {}".format(ct["name"], adapt_diff(actual.diff(entregada))))
                         estado = '1'
                 else:
-                    estado = '2'
+                    estado = '1' if modelo == 'E' else '2'
 
                 # Fecha APS / Estado
                 if modelo == 'M':
@@ -402,7 +402,6 @@ class FB2(StopMultiprocessBased):
 
                 if modelo == 'E':
                     tipo_inversion = '0'
-                    estado = '1'
 
                 # FINANCIADO
                 financiado = ''
@@ -418,7 +417,7 @@ class FB2(StopMultiprocessBased):
                         fecha_aps_year = int(data_pm.split('/')[2])
                         if estado == '2' and fecha_aps_year != int(self.year):
                             estado = '1'
-                        elif fecha_aps_year == int(self.year):
+                        elif fecha_aps_year == int(self.year) and modelo != 'E':
                             estado = '2'
                     else:
                         estado = '1'

--- a/libcnmc/cir_8_2021/FB4.py
+++ b/libcnmc/cir_8_2021/FB4.py
@@ -358,6 +358,8 @@ class FB4(StopMultiprocessBased):
                         estado = '1'
                 else:
                     estado = '1' if modelo == 'E' else '2'
+                    if data_pm and int(data_pm.split('/')[2]) != int(self.year):
+                        estado = '1'
 
                 if pos['cini'][4] == '3' and data_pm < data_baixa_limit and pos_obra == '':
                     estado = '0'
@@ -378,17 +380,6 @@ class FB4(StopMultiprocessBased):
 
                 if modelo == 'E':
                     tipo_inversion = '0'
-
-                # ESTADO no pot ser 2 si FECHA_APS < 2022
-                if not modelo == 'M':
-                    if data_pm:
-                        fecha_aps_year = int(data_pm.split('/')[2])
-                        if estado == '2' and fecha_aps_year != int(self.year):
-                            estado = '1'
-                        elif fecha_aps_year == int(self.year) and modelo != 'E':
-                            estado = '2'
-                    else:
-                        estado = '1'
 
                 # Buidem FECHA_IP si hi ha FECHA_BAJA
                 if fecha_baja:

--- a/libcnmc/cir_8_2021/FB4.py
+++ b/libcnmc/cir_8_2021/FB4.py
@@ -357,7 +357,7 @@ class FB4(StopMultiprocessBased):
                         self.output_m.put("{} {}".format(pos["name"], adapt_diff(actual.diff(entregada))))
                         estado = '1'
                 else:
-                    estado = '2'
+                    estado = '1' if modelo == 'E' else '2'
 
                 if pos['cini'][4] == '3' and data_pm < data_baixa_limit and pos_obra == '':
                     estado = '0'
@@ -378,7 +378,6 @@ class FB4(StopMultiprocessBased):
 
                 if modelo == 'E':
                     tipo_inversion = '0'
-                    estado = '1'
 
                 # ESTADO no pot ser 2 si FECHA_APS < 2022
                 if not modelo == 'M':
@@ -386,7 +385,7 @@ class FB4(StopMultiprocessBased):
                         fecha_aps_year = int(data_pm.split('/')[2])
                         if estado == '2' and fecha_aps_year != int(self.year):
                             estado = '1'
-                        elif fecha_aps_year == int(self.year):
+                        elif fecha_aps_year == int(self.year) and modelo != 'E':
                             estado = '2'
                     else:
                         estado = '1'

--- a/libcnmc/cir_8_2021/FB5.py
+++ b/libcnmc/cir_8_2021/FB5.py
@@ -533,6 +533,8 @@ class FB5(StopMultiprocessBased):
                 estado = '1'
         else:
             estado = '1' if condensador['model'] == 'E' else '2'
+            if o_fecha_aps and int(o_fecha_aps.split('/')[2]) != int(self.year):
+                estado = '1'
 
         if condensador['model'] == 'M':
             estado = ''
@@ -549,18 +551,6 @@ class FB5(StopMultiprocessBased):
 
         if condensador['model'] == 'E':
             tipo_inversion = '0'
-            estado = '1'
-
-        # ESTADO no pot ser 2 si FECHA_APS < 2022
-        if condensador['model'] != 'M':
-            if o_fecha_aps:
-                fecha_aps_year = int(o_fecha_aps.split('/')[2])
-                if estado == '2' and fecha_aps_year != int(self.year):
-                    estado = '1'
-                elif fecha_aps_year == int(self.year) and condensador['modelo'] != 'E':
-                    estado = '2'
-            else:
-                estado = '1'
 
         # Buidem FECHA_IP si hi ha FECHA_BAJA
         if fecha_baja:

--- a/libcnmc/cir_8_2021/FB5.py
+++ b/libcnmc/cir_8_2021/FB5.py
@@ -289,7 +289,7 @@ class FB5(StopMultiprocessBased):
                     actual.diff(entregada))))
                 estado = '1'
         else:
-            estado = '2'
+            estado = '1' if modelo == 'E' else '2'
 
         if modelo == 'M':
             estado = ''
@@ -306,7 +306,6 @@ class FB5(StopMultiprocessBased):
 
         if modelo == 'E':
             tipo_inversion = '0'
-            estado = '1'
 
         # ESTADO no pot ser 2 si FECHA_APS < 2022
         if not modelo == 'M':
@@ -533,7 +532,7 @@ class FB5(StopMultiprocessBased):
                     actual.diff(entregada))))
                 estado = '1'
         else:
-            estado = '2'
+            estado = '1' if condensador['model'] == 'E' else '2'
 
         if condensador['model'] == 'M':
             estado = ''
@@ -558,7 +557,7 @@ class FB5(StopMultiprocessBased):
                 fecha_aps_year = int(o_fecha_aps.split('/')[2])
                 if estado == '2' and fecha_aps_year != int(self.year):
                     estado = '1'
-                elif fecha_aps_year == int(self.year):
+                elif fecha_aps_year == int(self.year) and condensador['modelo'] != 'E':
                     estado = '2'
             else:
                 estado = '1'

--- a/libcnmc/cir_8_2021/FB6.py
+++ b/libcnmc/cir_8_2021/FB6.py
@@ -454,6 +454,8 @@ class FB6(StopMultiprocessBased):
                         estado = '1'
                 else:
                     estado = '1' if modelo == 'E' else '2'
+                    if data_pm and int(data_pm.split('/')[2]) != int(self.year):
+                        estado = '1'
 
                 if modelo == 'M':
                     estado = ''
@@ -470,17 +472,6 @@ class FB6(StopMultiprocessBased):
 
                 if modelo == 'E':
                     tipo_inversion = '0'
-
-                # ESTADO no pot ser 2 si FECHA_APS < 2022
-                if not modelo == 'M':
-                    if data_pm:
-                        fecha_aps_year = int(data_pm.split('/')[2])
-                        if estado == '2' and fecha_aps_year != int(self.year):
-                            estado = '1'
-                        elif fecha_aps_year == int(self.year) and modelo != 'E':
-                            estado = '2'
-                    else:
-                        estado = '1'
 
                 self.output_q.put([
                     o_fiabilitat,   # ELEMENTO FIABILIDAD

--- a/libcnmc/cir_8_2021/FB6.py
+++ b/libcnmc/cir_8_2021/FB6.py
@@ -453,7 +453,7 @@ class FB6(StopMultiprocessBased):
                         self.output_m.put("{} {}".format(cella["name"], adapt_diff(actual.diff(entregada))))
                         estado = '1'
                 else:
-                    estado = '2'
+                    estado = '1' if modelo == 'E' else '2'
 
                 if modelo == 'M':
                     estado = ''
@@ -470,7 +470,6 @@ class FB6(StopMultiprocessBased):
 
                 if modelo == 'E':
                     tipo_inversion = '0'
-                    estado = '1'
 
                 # ESTADO no pot ser 2 si FECHA_APS < 2022
                 if not modelo == 'M':
@@ -478,7 +477,7 @@ class FB6(StopMultiprocessBased):
                         fecha_aps_year = int(data_pm.split('/')[2])
                         if estado == '2' and fecha_aps_year != int(self.year):
                             estado = '1'
-                        elif fecha_aps_year == int(self.year):
+                        elif fecha_aps_year == int(self.year) and modelo != 'E':
                             estado = '2'
                     else:
                         estado = '1'

--- a/libcnmc/cir_8_2021/FB8.py
+++ b/libcnmc/cir_8_2021/FB8.py
@@ -204,6 +204,8 @@ class FB8(StopMultiprocessBased):
                         estado = '1'
                 else:
                     estado = '2'
+                    if data_pm and int(data_pm.split('/')[2]) != int(self.year):
+                        estado = '1'
 
                 if despatx.get('coco', False):
                     descripcio = despatx['coco']
@@ -212,16 +214,6 @@ class FB8(StopMultiprocessBased):
 
                 # L'any 2022 no es declaren subvencions PRTR
                 subvenciones_prtr = ''
-
-                # ESTADO no pot ser 2 si FECHA_APS < 2022
-                if data_pm:
-                    fecha_aps_year = int(data_pm.split('/')[2])
-                    if estado == '2' and fecha_aps_year != int(self.year):
-                        estado = '1'
-                    elif fecha_aps_year == int(self.year):
-                        estado = '2'
-                else:
-                    estado = '1'
 
                 self.output_q.put([
                     despatx['name'],                    # IDENTIFICADOR


### PR DESCRIPTION
# Descripción
- Se calcula el `ESTADO` de los elementos de los ficheros B para los elementos con `MODELO=E` (antiguamente siempre era `ESTADO=1`).
- Se hace una pequeña refactorización de la lógica que calcula el estado de un elemento.

# Ficheros modificados
- libcnmc/cir_8_2021/FB1.py
- libcnmc/cir_8_2021/FB2.py
- libcnmc/cir_8_2021/FB4.py
- libcnmc/cir_8_2021/FB5.py
- libcnmc/cir_8_2021/FB6.py
- libcnmc/cir_8_2021/FB8.py