### PR TITLE
Descartar el filtro de fecha de creación en los CUPS

### DIFF
--- a/libcnmc/cir_8_2021/FA1.py
+++ b/libcnmc/cir_8_2021/FA1.py
@@ -177,10 +177,7 @@ class FA1(StopMultiprocessBased):
                          ('active', '=', True),
                          '&',
                          ('data_baixa', '>=', data_ini),
-                         ('data_baixa', '<=', data_fi),
-                         '|',
-                         ('create_date', '<=', data_fi),
-                         ('create_date', '=', False)]
+                         ('data_baixa', '<=', data_fi)]
 
         ret_cups_ids = self.connection.GiscedataCupsPs.search(
             search_params, 0, 0, False, {'active_test': False})


### PR DESCRIPTION
# Descripción
- Se elimina el filtro de fecha de creación de los CUPS de este modo si un CUPS se crea el año siguiente de la retribución, pero con intención de ser usado para el año a retribuir, se incluirán igualmente

# Ficheros modificados
- A1
# Related
TASK-[75302](http://erp-ti.cloudvpn/action?model=project.task&views=%5B%5B999%2C%22graph%22%5D%2C%5B263%2C%22tree%22%5D%2C%5B1129%2C%22form%22%5D%5D&title=Les+meves+tasques+actuals&initialView=%7B%22id%22%3A1129%2C%22type%22%3A%22form%22%7D&action_id=759&action_type=ir.actions.act_window&res_id=75302&treeExpandable=false&limit=80&actionRawData=%7B%22domain%22%3A%22%5B%28%27user_id%27%2C+%27%3D%27%2C+uid%29%2C%28%27state%27%2C%27in%27%2C%28%27open%27%2C%27draft%27%29%29%2C+%28%27stage_id.name%27%2C+%27%21%3D%27%2C+%27Permanent%27%29%5D%22%7D)
