### PR TITLE
Nuevo flag para incluir elementos de tipo Fusible AT en el fichero B2.2

### DIFF
--- a/libcnmc/cir_8_2021/FB2_2.py
+++ b/libcnmc/cir_8_2021/FB2_2.py
@@ -28,6 +28,7 @@ class FB2_2(StopMultiprocessBased):
         self.base_object = 'Cel·les'
         self.fiabilitat = kwargs.get("fiabilitat")
         self.doslmesp = kwargs.get("doslmesp")
+        self.incloure_fusat = kwargs.pop('incloure_fusat', False)
 
     def get_sequence(self):
         """
@@ -36,10 +37,9 @@ class FB2_2(StopMultiprocessBased):
         :return: None
         """
         cella_obj = self.connection.GiscedataCellesCella
-        search_params = [
-            ('cini', '=like', 'I28%'),
-            ("tipus_element.codi", "!=", "FUS_AT")
-        ]
+        search_params = [('cini', '=like', 'I28%')]
+        if not self.incloure_fusat:
+            search_params += [("tipus_element.codi", "!=", "FUS_AT")]
 
         data_pm = '{}-01-01'.format(self.year + 1)
         data_baixa = '{}-12-31'.format(self.year)

--- a/libcnmc/cli_8_2021.py
+++ b/libcnmc/cli_8_2021.py
@@ -457,6 +457,7 @@ def cir_8_2021_fb2_1(**kwargs):
               help='Contrasenya usuari ERP')
 @click.option('-d', '--database', help='Nom de la base de dades')
 @click.option('--num-proc', default=N_PROC, type=click.INT)
+@click.option('--incloure_fusat/--no-incloure_fusat', default=False, help="Incloure fusible AT")
 def cir_8_2021_fb2_2(**kwargs):
     """
     Click entry to generate the B2_2: CELDAS EN CTS
@@ -477,6 +478,8 @@ def cir_8_2021_fb2_2(**kwargs):
         num_proc=kwargs['num_proc'],
         codi_r1=kwargs['codi_r1'],
         year=kwargs['year'],
+        incloure_fusat=kwargs['incloure_fusat']
+
     )
     proc.calc()
 


### PR DESCRIPTION
# Descripcion
- Incluir opcionalmente todos los elementos de tipo **Fusible AT** en la exportación de **Celdas y Elementos de Corte** que por defecto estaban excluidos

# Ficheros modificados
- B2.2
