### PR TITLE
Inicializar valores de energia a 0

### DIFF
--- a/libcnmc/cir_8_2021/FA2.py
+++ b/libcnmc/cir_8_2021/FA2.py
@@ -373,10 +373,10 @@ class FA2(StopMultiprocessBased):
                     o_cups_ssaa = '' # Es força a valor fixe buit
 
                     # Energies
-                    o_energia_activa_producida = ''
-                    o_energia_activa_consumida = ''
-                    o_energia_reactiva_producida = ''
-                    o_energia_reactiva_consumida = ''
+                    o_energia_activa_producida = '0,000'
+                    o_energia_activa_consumida = '0,000'
+                    o_energia_reactiva_producida = '0,000'
+                    o_energia_reactiva_consumida = '0,000'
 
                     if gen.get('cne_anual_activa_generada'):
                         o_energia_activa_producida = gen[


### PR DESCRIPTION
# Descripcion
- Inicializar valores de las energías a 0. La inicialización se realiza para las instalaciones de RECORE pero en los generadores de autoconsumo no.

# Ficheros modificados
- A2
