### PR TITLE
Fix a 2 decimales

### DIFF
--- a/libcnmc/res_4667/MACRO.py
+++ b/libcnmc/res_4667/MACRO.py
@@ -57,7 +57,7 @@ class MACRO(StopMultiprocessBased):
                 macro = O.GiscedataCnmcResum_any.read(item, fields_to_read)
                 output = [
                     macro["anyo"],
-                    format_f(float(macro["macro_crec_pib"]), 4),
+                    format_f(float(macro["macro_crec_pib"]), 2),
                     format_f(float(macro["macro_pib_prev"]), 2) or "0.00",
                     format_f(float(macro["macro_limite_sector"]), 2) or "0.00",
                     format_f(float(macro["macro_inc_demanda_sector"]), 2) or "0.00"

--- a/libcnmc/res_4667/RES.py
+++ b/libcnmc/res_4667/RES.py
@@ -77,7 +77,7 @@ class RES(StopMultiprocessBased):
 
                 resumen = O.GiscedataCnmcResum_any.read(item, fields_to_read)
                 vpi_superado_prv = str(resumen["vpi_sup"]).upper()
-                demanda_empresa_p0 = format_f(resumen["demanda_empresa_p0"], 3)
+                demanda_empresa_p0 = format_f(resumen["demanda_empresa_p0"], 2)
                 if len(demanda_empresa_p0) > 8:
                     demanda_empresa_p0 = format_f(
                         resumen["demanda_empresa_p0"], 1


### PR DESCRIPTION
# Para el versionado automático seleccionar uno de los siguientes labels:
- **patch**: Patch auto version v_._.X

De esta forma el proceso de versionado se hará de forma automática

# Descripcion
- Corrección del número de decimales en la generación de los archivos PI_MACRO y PI_RESUMEN para solventar los errores de `ScalePrecisionValidator` reportados por la CNMC.
- Se ha ajustado el redondeo a 2 decimales en el campo `CrecPib` (`macro_crec_pib`).
- Se ha ajustado el redondeo a 2 decimales en el campo `DemandaEmpresaP0`.

# Ficheros modificados
- `libcnmc/res_4667/MACRO.py`
- `libcnmc/res_4667/RES.py`