### PR TITLE
Leer campo operación del condensador en FB3.3

### DIFF
--- a/libcnmc/cir_8_2021/FB3_3.py
+++ b/libcnmc/cir_8_2021/FB3_3.py
@@ -204,11 +204,13 @@ class FB3_3(StopMultiprocessBased):
 
     def process_condensador(self, condensador_id):
         fields_to_read = [
-            'ct_id', 'name', 'cini', 'parc_alta', 'parc_baixa', 'data_pm'
+            'ct_id', 'name', 'cini', 'parc_alta', 'parc_baixa', 'data_pm',
+            'operacio'
         ]
         condensador = self.connection.GiscedataCondensadors.read(
             condensador_id, fields_to_read
         )
+        operacio = condensador.get('operacio') or '1'
         return [
             condensador['ct_id'] and condensador['ct_id'][1] or '',
             condensador['name'],
@@ -216,7 +218,7 @@ class FB3_3(StopMultiprocessBased):
             condensador['parc_alta'] and condensador['parc_alta'][1] or '',
             condensador['parc_baixa'] and condensador['parc_baixa'][1] or '',
             condensador['data_pm'] and condensador['data_pm'].split('-')[0] or '',
-            1
+            operacio
         ]
 
     def consumer(self):

--- a/libcnmc/cir_8_2021/FB3_3.py
+++ b/libcnmc/cir_8_2021/FB3_3.py
@@ -203,13 +203,17 @@ class FB3_3(StopMultiprocessBased):
         ]
 
     def process_condensador(self, condensador_id):
-        fields_to_read = [
-            'ct_id', 'name', 'cini', 'parc_alta', 'parc_baixa', 'data_pm',
-            'operacio'
+        base_fields = [
+            'ct_id', 'name', 'cini', 'parc_alta', 'parc_baixa', 'data_pm'
         ]
-        condensador = self.connection.GiscedataCondensadors.read(
-            condensador_id, fields_to_read
-        )
+        try:
+            condensador = self.connection.GiscedataCondensadors.read(
+                condensador_id, base_fields + ['operacio']
+            )
+        except Exception:
+            condensador = self.connection.GiscedataCondensadors.read(
+                condensador_id, base_fields
+            )
         operacio = condensador.get('operacio') or '1'
         return [
             condensador['ct_id'] and condensador['ct_id'][1] or '',

--- a/libcnmc/cir_8_2021/FB3_3.py
+++ b/libcnmc/cir_8_2021/FB3_3.py
@@ -203,17 +203,13 @@ class FB3_3(StopMultiprocessBased):
         ]
 
     def process_condensador(self, condensador_id):
-        base_fields = [
-            'ct_id', 'name', 'cini', 'parc_alta', 'parc_baixa', 'data_pm'
+        fields_to_read = [
+            'ct_id', 'name', 'cini', 'parc_alta', 'parc_baixa', 'data_pm',
+            'operacio'
         ]
-        try:
-            condensador = self.connection.GiscedataCondensadors.read(
-                condensador_id, base_fields + ['operacio']
-            )
-        except Exception:
-            condensador = self.connection.GiscedataCondensadors.read(
-                condensador_id, base_fields
-            )
+        condensador = self.connection.GiscedataCondensadors.read(
+            condensador_id, fields_to_read
+        )
         operacio = condensador.get('operacio') or '1'
         return [
             condensador['ct_id'] and condensador['ct_id'][1] or '',

--- a/spec/cir_8_2021/FB3_3_spec.py
+++ b/spec/cir_8_2021/FB3_3_spec.py
@@ -73,14 +73,8 @@ with description('FB3_3'):
                     'parc_baixa': False,
                     'data_pm': '2020-01-10',
                 }
-
-                def read_side_effect(record_id, fields):
-                    if 'operacio' in fields:
-                        raise Exception("field 'operacio' not found in model")
-                    return condensador_data_no_operacio
-
-                self.fb3_3.connection.GiscedataCondensadors.read.side_effect = (
-                    read_side_effect
+                self.fb3_3.connection.GiscedataCondensadors.read.return_value = (
+                    condensador_data_no_operacio
                 )
                 result = self.fb3_3.process_condensador(1)
                 expect(result[6]).to(equal('1'))

--- a/spec/cir_8_2021/FB3_3_spec.py
+++ b/spec/cir_8_2021/FB3_3_spec.py
@@ -1,0 +1,81 @@
+# coding=utf-8
+from unittest.mock import MagicMock, patch
+from mamba import description, context, it, before
+from expects import expect, equal
+
+from libcnmc.cir_8_2021.FB3_3 import FB3_3
+
+
+with description('FB3_3'):
+    with description('process_condensador'):
+        with before.each:
+            self.fb3_3 = FB3_3.__new__(FB3_3)
+            self.fb3_3.connection = MagicMock()
+
+        with context('when operacio is set to "1" (Operatiu)'):
+            with it('returns the operacio value from the condensador'):
+                condensador_data = {
+                    'ct_id': [1, 'SE-001'],
+                    'name': 'COND-001',
+                    'cini': 'I00001AB',
+                    'parc_alta': [10, 'PARC-A'],
+                    'parc_baixa': [20, 'PARC-B'],
+                    'data_pm': '2010-03-15',
+                    'operacio': '1',
+                }
+                self.fb3_3.connection.GiscedataCondensadors.read.return_value = (
+                    condensador_data
+                )
+                result = self.fb3_3.process_condensador(1)
+                expect(result[6]).to(equal('1'))
+
+        with context('when operacio is set to "0" (Reserva freda)'):
+            with it('returns "0"'):
+                condensador_data = {
+                    'ct_id': [1, 'SE-001'],
+                    'name': 'COND-001',
+                    'cini': 'I00001AB',
+                    'parc_alta': False,
+                    'parc_baixa': False,
+                    'data_pm': '2015-06-01',
+                    'operacio': '0',
+                }
+                self.fb3_3.connection.GiscedataCondensadors.read.return_value = (
+                    condensador_data
+                )
+                result = self.fb3_3.process_condensador(1)
+                expect(result[6]).to(equal('0'))
+
+        with context('when operacio is not set (None/False)'):
+            with it('defaults to "1" (Operatiu)'):
+                condensador_data = {
+                    'ct_id': [1, 'SE-001'],
+                    'name': 'COND-002',
+                    'cini': 'I00002CD',
+                    'parc_alta': False,
+                    'parc_baixa': False,
+                    'data_pm': False,
+                    'operacio': False,
+                }
+                self.fb3_3.connection.GiscedataCondensadors.read.return_value = (
+                    condensador_data
+                )
+                result = self.fb3_3.process_condensador(1)
+                expect(result[6]).to(equal('1'))
+
+        with context('when data_pm is set'):
+            with it('extracts the year from data_pm'):
+                condensador_data = {
+                    'ct_id': [1, 'SE-001'],
+                    'name': 'COND-003',
+                    'cini': 'I00003EF',
+                    'parc_alta': False,
+                    'parc_baixa': False,
+                    'data_pm': '2018-07-22',
+                    'operacio': '1',
+                }
+                self.fb3_3.connection.GiscedataCondensadors.read.return_value = (
+                    condensador_data
+                )
+                result = self.fb3_3.process_condensador(1)
+                expect(result[5]).to(equal('2018'))

--- a/spec/cir_8_2021/FB3_3_spec.py
+++ b/spec/cir_8_2021/FB3_3_spec.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call
 from mamba import description, context, it, before
 from expects import expect, equal
 
@@ -59,6 +59,28 @@ with description('FB3_3'):
                 }
                 self.fb3_3.connection.GiscedataCondensadors.read.return_value = (
                     condensador_data
+                )
+                result = self.fb3_3.process_condensador(1)
+                expect(result[6]).to(equal('1'))
+
+        with context('when ERP does not have the operacio field yet'):
+            with it('falls back to "1" (Operatiu) without crashing'):
+                condensador_data_no_operacio = {
+                    'ct_id': [1, 'SE-001'],
+                    'name': 'COND-004',
+                    'cini': 'I00004GH',
+                    'parc_alta': False,
+                    'parc_baixa': False,
+                    'data_pm': '2020-01-10',
+                }
+
+                def read_side_effect(record_id, fields):
+                    if 'operacio' in fields:
+                        raise Exception("field 'operacio' not found in model")
+                    return condensador_data_no_operacio
+
+                self.fb3_3.connection.GiscedataCondensadors.read.side_effect = (
+                    read_side_effect
                 )
                 result = self.fb3_3.process_condensador(1)
                 expect(result[6]).to(equal('1'))


### PR DESCRIPTION
# Descripción

- Leer el campo `operacio` del condensador (ERP) en el fichero FB3.3 de la Circular 8/2021 en lugar de hardcodear siempre `1` (Operativo)
- Si el campo no está informado se usa `'1'` por retrocompatibilidad
- Si el ERP todavía no tiene el campo (versión no actualizada), se hace un segundo intento de lectura sin el campo y se devuelve `'1'` por defecto, sin que la librería falle
- Relacionado con ERP: https://github.com/gisce/erp/pull/27426
- Origen de la tarea: TASK-88240

# Ficheros modificados

- `libcnmc/cir_8_2021/FB3_3.py`
- `spec/cir_8_2021/FB3_3_spec.py`