### PR TITLE
Las maquinas en reserva no se deben declarar en el B5

### DIFF
--- a/libcnmc/cir_8_2021/FB5.py
+++ b/libcnmc/cir_8_2021/FB5.py
@@ -29,6 +29,9 @@ class FB5(StopMultiprocessBased):
             ('criteri_regulatori', '!=', 'excloure'),
             ('reductor', '=', True),
             ('id_estat.cnmc_inventari', '=', True),
+            # Els trafos en reserva (operació '0') s'han de declarar
+            # únicament al formulari B3.3 (FAQ CNMC 2025, apartat B5).
+            ('id_estat.operacio', '!=', '0'),
         ]
         trafo_ids = [
             'T.{}'.format(x)
@@ -42,6 +45,9 @@ class FB5(StopMultiprocessBased):
             ('criteri_regulatori', '!=', 'excloure'),
             ('ct_id.id_installacio.name', '=', 'SE'),
             ('tipus', '=', '2'),
+            # Els condensadors en reserva s'han de declarar
+            # únicament al formulari B3.3 (FAQ CNMC 2025, apartat B5).
+            ('operacio', '!=', '0'),
         ]
 
         condensadors_ids = [


### PR DESCRIPTION
# Descripcion
- En el fichero B5 no deben ir las máquinas (transformadores o condensadores) en estado `Reserva fría`. Deben informarse en el B3.3

# Ficheros modificados
- B5
