### PR TITLE
Adaptación del formato CNAE a NN.NN (RD 10/2025) para declaraciones Circular 8/2021

### DIFF
--- a/libcnmc/cir_8_2021/FA1.py
+++ b/libcnmc/cir_8_2021/FA1.py
@@ -794,7 +794,7 @@ class FA1(StopMultiprocessBased):
                     format_f(res_srid[0], decimals=3),                  # X
                     format_f(res_srid[1], decimals=3),                  # Y
                     '0,000',                                            # Z
-                    format_cnae(o_cnae),                                    # CNAE
+                    format_cnae(o_cnae),                                # CNAE
                     o_cod_tfa,                                          # Codigo de tarifa
                     o_name,                                             # CUPS
                     o_codi_ine_mun,                                     # Municipio

--- a/libcnmc/cir_8_2021/FA1.py
+++ b/libcnmc/cir_8_2021/FA1.py
@@ -17,6 +17,19 @@ VALID_POLISSA_STATES = [
     'tall', 'activa', 'baixa', 'modcontractual', 'impagament']
 
 
+def format_cnae(cnae):
+    """
+    Dona format al CNAE afegint el punt separador (NN.NN).
+    El RD 10/2025 (CNAE-2025) i la FAQ 2026 de la Circular 8/2021
+    (seccio 4.1.1) exigeixen aquest format a les declaracions.
+    Els codis de 3 digits o menys (grups estructurals inactius)
+    es deixen tal qual per seguretat, tot i que no haurien d'apareixer.
+    """
+    if isinstance(cnae, basestring) and len(cnae) == 4:
+        return cnae[:2] + '.' + cnae[2:]
+    return cnae
+
+
 class FA1(StopMultiprocessBased):
     def __init__(self, **kwargs):
         """
@@ -781,7 +794,7 @@ class FA1(StopMultiprocessBased):
                     format_f(res_srid[0], decimals=3),                  # X
                     format_f(res_srid[1], decimals=3),                  # Y
                     '0,000',                                            # Z
-                    o_cnae,                                             # CNAE
+                    format_cnae(o_cnae),                                    # CNAE
                     o_cod_tfa,                                          # Codigo de tarifa
                     o_name,                                             # CUPS
                     o_codi_ine_mun,                                     # Municipio


### PR DESCRIPTION
# Descripción

**Adaptación del formato CNAE a NN.NN (RD 10/2025) para declaraciones Circular 8/2021**

El **RD 10/2025** aprueba la nueva clasificación **CNAE-2025**, que cambia la estructura de los códigos de actividad. Como consecuencia, la **FAQ 2026 de la Circular 8/2021** (sección 4.1.1) establece que el campo CNAE en las declaraciones debe entregarse en formato **NN.NN** (con punto separador entre los dos pares de dígitos), en lugar del formato anterior NNNN (4 dígitos sin separador).

El validador de la CNMC (SGD/SGTD) rechazará los ficheros que entreguen el CNAE sin el punto.

---

# Ficheros modificados

## A1

### Razón del cambio

El formulario FA1 (declaración anual de CUPS) es el único de la Circular 8/2021 que incluye el campo CNAE. La CNMC exige el formato NN.NN para validar el fichero.

### Resultados

| CNAE en BD (name) | Antes (FA1) | Después (FA1) | Válido CNMC |
|---|---|---|---|
| `9820` | `9820` | `98.20` | ✅ |
| `0146` | `0146` | `01.46` | ✅ |
| `3511` | `3511` | `35.11` | ✅ |
| `982` | `982` | `982` | N/A (estructural, inactivo) |
| `''` | `''` | `''` | N/A (vacío) |

Ejemplo de línea en el fichero generado (campo CNAE resaltado):

```csv
N001;0,000;0,000;0,000;98.20;01.02A;ES0123456789012345AB;28001;28;...
                       ^^^^^
```
