### PR TITLE
Corrección de intervalos de derechos de extensión/reconexión en formulario A1

### DIFF
--- a/libcnmc/cir_8_2021/FA1.py
+++ b/libcnmc/cir_8_2021/FA1.py
@@ -142,7 +142,7 @@ class FA1(StopMultiprocessBased):
         polisses_baixa_id = O.GiscedataPolissa.search(
             [
                 ("data_baixa", "<=", "{}-12-31".format(self.year - 1)),
-                ("data_baixa", ">", "{}-01-01".format(self.year - years)),
+                ("data_baixa", ">=", "{}-01-01".format(self.year - years)),
                 ("tarifa", "in", tarifas)
             ],
             0, 0, False, {'active_test': False}
@@ -204,8 +204,8 @@ class FA1(StopMultiprocessBased):
             if set(cups['polisses']).intersection(self.modcons_in_year):
                 ret_cups.append(cups["id"])
         if self.generate_derechos:
-            cups_derechos_bt = self.get_derechos(TARIFAS_BT, 2)
-            cups_derechos_at = self.get_derechos(TARIFAS_AT, 4)
+            cups_derechos_bt = self.get_derechos(TARIFAS_BT, 3)
+            cups_derechos_at = self.get_derechos(TARIFAS_AT, 5)
             return list(set(ret_cups + cups_derechos_at + cups_derechos_bt))
         else:
             return ret_cups


### PR DESCRIPTION
## Descripción
- Se corrige el cálculo de los CUPS con derechos de extensión y reconexión en el formulario **A1** (Circular 8/2021).

### Problema
- El método `get_derechos` del `FA1` buscaba pólizas dadas de baja con un intervalo incorrecto:
  - **BT**: `years=2` → `data_baixa > {año-2}-01-01` (se perdía ~1 año)
  - **AT**: `years=4` → `data_baixa > {año-4}-01-01` (se perdía ~1 año)

Esto provocaba que CUPS con derechos de extensión/reconexión aún vigentes no se declarasen en el A1.

### Detalle
**Intervalos correctos según solicitud:**
- **BT**: derechos vigentes hasta **3 años** después de la baja → `data_baixa >= {año-3}-01-01`
- **AT**: derechos vigentes hasta **5 años** después de la baja → `data_baixa >= {año-5}-01-01`

**Operador `>=`**: se cambia de `>` a `>=` para incluir el caso límite donde `data_baixa` es exactamente `{año-n}-01-01` (ej: baja el 1 de enero de hace 3 años, el derecho cubre 1 día del año de declaración).

**Ejemplo con año de declaración 2025:**
- Póliza BT cancelada el 15/06/2022: derechos hasta 15/06/2025. Con `years=2` se buscaba desde 02/01/2023 → **no se incluía**. Con `years=3` se busca desde 01/01/2022 → **se incluye**.
- Póliza AT cancelada el 15/06/2020: derechos hasta 15/06/2025. Con `years=4` se buscaba desde 02/01/2021 → **no se incluía**. Con `years=5` se busca desde 01/01/2020 → **se incluye**.